### PR TITLE
Improve endpoint error reporting

### DIFF
--- a/src/main/java/bio/terra/cda/app/controller/GlobalExceptionHandler.java
+++ b/src/main/java/bio/terra/cda/app/controller/GlobalExceptionHandler.java
@@ -2,7 +2,11 @@ package bio.terra.cda.app.controller;
 
 import bio.terra.cda.common.exception.ErrorReportException;
 import bio.terra.cda.generated.model.ErrorReport;
+
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -46,8 +50,15 @@ public class GlobalExceptionHandler {
   private ResponseEntity<ErrorReport> buildErrorReport(
       Throwable ex, HttpStatus statusCode, List<String> causes) {
     logger.error("Global exception handler: catch stack", ex);
+
+    List<String> collectCauses = new ArrayList<>();
     for (Throwable cause = ex; cause != null; cause = cause.getCause()) {
       logger.error("   cause: " + cause.toString());
+      collectCauses.add(cause.getMessage());
+    }
+
+    if (causes == null) {
+      causes = collectCauses;
     }
     ErrorReport errorReport =
         new ErrorReport().message(ex.getMessage()).statusCode(statusCode.value()).causes(causes);

--- a/src/main/java/bio/terra/cda/app/service/QueryService.java
+++ b/src/main/java/bio/terra/cda/app/service/QueryService.java
@@ -86,7 +86,7 @@ public class QueryService {
       queryJob = runJob(queryJob);
       return new QueryResult(queryString, getJobResults(queryJob));
     } catch (Throwable t) {
-      throw new BadQueryException(String.format("SQL: %s", queryString), t);
+      throw new BadQueryException(String.format("Error calling BigQuery: '%s'", queryString), t);
     }
   }
 }


### PR DESCRIPTION
If the user doesn't provide causes for an exception, populate it using the thrown exception's causes.