### PR TITLE
Add "dry run" feature to boolean query endpoint.

### DIFF
--- a/src/main/java/bio/terra/cda/app/controller/QueryApiController.java
+++ b/src/main/java/bio/terra/cda/app/controller/QueryApiController.java
@@ -5,7 +5,7 @@ import bio.terra.cda.app.util.QueryTranslator;
 import bio.terra.cda.generated.controller.QueryApi;
 import bio.terra.cda.generated.model.InlineResponse200;
 import bio.terra.cda.generated.model.Query;
-import bio.terra.cda.service.ping.PingService;
+import bio.terra.cda.app.service.PingService;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Objects;

--- a/src/main/java/bio/terra/cda/app/service/PingService.java
+++ b/src/main/java/bio/terra/cda/app/service/PingService.java
@@ -1,6 +1,6 @@
-package bio.terra.cda.service.ping;
+package bio.terra.cda.app.service;
 
-import bio.terra.cda.service.ping.exception.BadPingException;
+import bio.terra.cda.app.service.exception.BadPingException;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 

--- a/src/main/java/bio/terra/cda/app/service/exception/BadPingException.java
+++ b/src/main/java/bio/terra/cda/app/service/exception/BadPingException.java
@@ -1,4 +1,4 @@
-package bio.terra.cda.service.ping.exception;
+package bio.terra.cda.app.service.exception;
 
 import bio.terra.cda.common.exception.BadRequestException;
 import java.util.List;

--- a/src/main/java/bio/terra/cda/app/util/QueryTranslator.java
+++ b/src/main/java/bio/terra/cda/app/util/QueryTranslator.java
@@ -5,19 +5,12 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class QueryTranslator {
-  public final String table;
-  public final Query query;
 
-  public QueryTranslator(String table, Query query) {
-    this.table = table;
-    this.query = query;
-  }
-
-  public String sql() {
+  public static String sql(String table, Query query) {
     var fromClause =
         Stream.concat(
-                Stream.of(this.table),
-                getUnnestColumns(this.query)
+                Stream.of(table),
+                getUnnestColumns(query)
                     .distinct()
                     .map(s -> String.format("UNNEST(%1$s) AS _%1$s", s)))
             .collect(Collectors.joining(", "));
@@ -53,7 +46,7 @@ public class QueryTranslator {
     return null;
   }
 
-  private String queryString(Query query) {
+  private static String queryString(Query query) {
     switch (query.getNodeType()) {
       case QUOTED:
         return String.format("'%s'", query.getValue());

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -103,7 +103,7 @@ paths:
           name: dryRun
           schema:
             type: boolean
-          allowEmptyValue: true
+            default: false
 
       requestBody:
         description: The boolean query

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -98,6 +98,12 @@ paths:
         - $ref: '#/components/parameters/DatasetVersion'
         - $ref: '#/components/parameters/ResultOffset'
         - $ref: '#/components/parameters/ResultLimit'
+        - in: query
+          description: If true, don't run the query, only generate and return it.
+          name: dryRun
+          schema:
+            type: boolean
+          allowEmptyValue: true
 
       requestBody:
         description: The boolean query
@@ -227,7 +233,7 @@ components:
       type: object
       properties:
         release-date:
-          $ref: DateType
+          $ref: '#/components/schemas/DateType'
         cda-version:
           type: string
         cda-model:
@@ -251,7 +257,7 @@ components:
         version:
           type: string
         date:
-          $ref: DateType
+          $ref: '#/components/schemas/DateType'
 
     Model:
       type: object
@@ -259,7 +265,7 @@ components:
         version:
           type: string
         date:
-          $ref: DateType
+          $ref: '#/components/schemas/DateType'
         model:
           type: object
           properties: {}

--- a/src/test/java/bio/terra/cda/app/controller/QueryApiControllerTest.java
+++ b/src/test/java/bio/terra/cda/app/controller/QueryApiControllerTest.java
@@ -1,31 +1,66 @@
 package bio.terra.cda.app.controller;
 
+import bio.terra.cda.app.service.PingService;
+import bio.terra.cda.app.service.QueryService;
+import bio.terra.cda.generated.model.InlineResponse200;
+import bio.terra.cda.generated.model.Query;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import bio.terra.cda.app.service.QueryService;
-import bio.terra.cda.generated.model.Query;
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-
+@Tag("unit")
 @SpringBootTest
+@AutoConfigureMockMvc
 class QueryApiControllerTest {
 
-  @MockBean QueryService queryService;
+  @Autowired
+  private MockMvc mvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockBean
+  private PingService pingService;
+
+  @MockBean
+  private QueryService queryService;
+
+  private void callQueryApi(boolean dryRun) throws Exception {
+    var query = new Query().nodeType(Query.NodeTypeEnum.COLUMN).value("test");
+    var expected = "SELECT * FROM gdc-bq-sample.cda_mvp.v0 WHERE test";
+
+    var post =
+            post("/api/v1/boolean-query/v0?dryRun={dryRun}", dryRun)
+            .content(objectMapper.writeValueAsString(query))
+            .contentType(MediaType.APPLICATION_JSON);
+    var result = mvc.perform(post).andExpect(status().isOk()).andReturn();
+    var response = objectMapper.readValue(result.getResponse().getContentAsString(), InlineResponse200.class);
+    assertThat(response.getQuerySql(), equalTo(expected));
+  }
 
   @Test
-  void booleanQuery() {
-    var controller = new QueryApiController(null, queryService);
-    var query = new Query().nodeType(Query.NodeTypeEnum.COLUMN).value("test");
-    var result = controller.booleanQuery("version", query, 0, 0, true);
+  void booleanQueryDryRun() throws Exception {
+    callQueryApi(true);
     verify(queryService, never()).runQuery(anyString());
 
     reset(queryService);
-    var result2 = controller.booleanQuery("version", query, 0, 0, false);
+    callQueryApi(false);
     verify(queryService, only()).runQuery(anyString());
   }
 }

--- a/src/test/java/bio/terra/cda/app/controller/QueryApiControllerTest.java
+++ b/src/test/java/bio/terra/cda/app/controller/QueryApiControllerTest.java
@@ -1,0 +1,31 @@
+package bio.terra.cda.app.controller;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+
+import bio.terra.cda.app.service.QueryService;
+import bio.terra.cda.generated.model.Query;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest
+class QueryApiControllerTest {
+
+  @MockBean QueryService queryService;
+
+  @Test
+  void booleanQuery() {
+    var controller = new QueryApiController(null, queryService);
+    var query = new Query().nodeType(Query.NodeTypeEnum.COLUMN).value("test");
+    var result = controller.booleanQuery("version", query, 0, 0, true);
+    verify(queryService, never()).runQuery(anyString());
+
+    reset(queryService);
+    var result2 = controller.booleanQuery("version", query, 0, 0, false);
+    verify(queryService, only()).runQuery(anyString());
+  }
+}

--- a/src/test/java/bio/terra/cda/app/util/QueryTranslatorTest.java
+++ b/src/test/java/bio/terra/cda/app/util/QueryTranslatorTest.java
@@ -24,7 +24,7 @@ class QueryTranslatorTest {
     String expectedSql = String.format("SELECT * FROM %s WHERE (project_id = 'TCGA-OV')", TABLE);
 
     Query query = objectMapper.readValue(jsonQuery, Query.class);
-    String translatedQuery = new QueryTranslator(TABLE, query).sql();
+    String translatedQuery = QueryTranslator.sql(TABLE, query);
 
     assertEquals(expectedSql, translatedQuery);
   }
@@ -41,7 +41,7 @@ class QueryTranslatorTest {
             TABLE);
 
     Query query = objectMapper.readValue(jsonQuery, Query.class);
-    String translatedQuery = new QueryTranslator(TABLE, query).sql();
+    String translatedQuery = QueryTranslator.sql(TABLE, query);
 
     assertEquals(EXPECTED_SQL, translatedQuery);
   }

--- a/src/test/java/bio/terra/cda/service/ping/PingRestTest.java
+++ b/src/test/java/bio/terra/cda/service/ping/PingRestTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import bio.terra.cda.app.Main;
 import bio.terra.cda.app.service.PingService;
+import bio.terra.cda.app.service.QueryService;
 import bio.terra.cda.generated.model.ErrorReport;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Tag;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -38,6 +40,8 @@ public class PingRestTest {
   @Autowired private ObjectMapper objectMapper;
 
   @Autowired private PingService pingService;
+
+  @MockBean private QueryService queryService;
 
   @Test
   public void testRestPong() throws Exception {

--- a/src/test/java/bio/terra/cda/service/ping/PingRestTest.java
+++ b/src/test/java/bio/terra/cda/service/ping/PingRestTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import bio.terra.cda.app.Main;
+import bio.terra.cda.app.service.PingService;
 import bio.terra.cda.generated.model.ErrorReport;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Tag;

--- a/src/test/java/bio/terra/cda/service/ping/PingServiceTest.java
+++ b/src/test/java/bio/terra/cda/service/ping/PingServiceTest.java
@@ -9,7 +9,8 @@ package bio.terra.cda.service.ping;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 
-import bio.terra.cda.service.ping.exception.BadPingException;
+import bio.terra.cda.app.service.PingService;
+import bio.terra.cda.app.service.exception.BadPingException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;


### PR DESCRIPTION
Added a `dryRun` argument to query that returns the SQL without executing it.

I also cleaned up the query service, translator code a little. The query service is now an injectable service, and the translator code is now a static class.

This addresses https://github.com/CancerDataAggregator/cda-service/issues/21