### PR TITLE
Support nested columns

### DIFF
--- a/src/main/java/bio/terra/cda/app/controller/QueryApiController.java
+++ b/src/main/java/bio/terra/cda/app/controller/QueryApiController.java
@@ -24,7 +24,6 @@ public class QueryApiController implements QueryApi {
   private final QueryService queryService;
   private final ApplicationConfiguration applicationConfiguration;
 
-
   @Autowired
   public QueryApiController(
       QueryService queryService, ApplicationConfiguration applicationConfiguration) {

--- a/src/main/java/bio/terra/cda/app/util/QueryTranslator.java
+++ b/src/main/java/bio/terra/cda/app/util/QueryTranslator.java
@@ -1,8 +1,6 @@
 package bio.terra.cda.app.util;
 
 import bio.terra.cda.generated.model.Query;
-
-import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -25,10 +23,12 @@ public class QueryTranslator {
         return Stream.empty();
       case COLUMN:
         var parts = query.getValue().split("\\.");
-        return IntStream.range(0, parts.length - 1).mapToObj(
-                i -> i == 0 ? String.format("UNNEST(%1$s) AS _%1$s", parts[i])
-                        : String.format("UNNEST(_%1$s.%2$s) AS _%2$s", parts[i - 1], parts[i])
-        );
+        return IntStream.range(0, parts.length - 1)
+            .mapToObj(
+                i ->
+                    i == 0
+                        ? String.format("UNNEST(%1$s) AS _%1$s", parts[i])
+                        : String.format("UNNEST(_%1$s.%2$s) AS _%2$s", parts[i - 1], parts[i]));
       default:
         return Stream.concat(getUnnestColumns(query.getL()), getUnnestColumns(query.getR()));
     }

--- a/src/test/java/bio/terra/cda/app/util/QueryTranslatorTest.java
+++ b/src/test/java/bio/terra/cda/app/util/QueryTranslatorTest.java
@@ -50,8 +50,11 @@ class QueryTranslatorTest {
   public void testQueryNested() throws Exception {
     String jsonQuery = Files.readString(TEST_FILES.resolve("query3.json"));
 
-    String expectedSql = String.format("SELECT * FROM %s, UNNEST(A) AS _A, UNNEST(_A.B) AS _B, " +
-            "UNNEST(_B.C) AS _C, UNNEST(_C.D) AS _D WHERE (_D.column = value)", TABLE);
+    String expectedSql =
+        String.format(
+            "SELECT * FROM %s, UNNEST(A) AS _A, UNNEST(_A.B) AS _B, "
+                + "UNNEST(_B.C) AS _C, UNNEST(_C.D) AS _D WHERE (_D.column = value)",
+            TABLE);
 
     Query query = objectMapper.readValue(jsonQuery, Query.class);
     String translatedQuery = QueryTranslator.sql(TABLE, query);

--- a/src/test/java/bio/terra/cda/app/util/QueryTranslatorTest.java
+++ b/src/test/java/bio/terra/cda/app/util/QueryTranslatorTest.java
@@ -45,4 +45,17 @@ class QueryTranslatorTest {
 
     assertEquals(EXPECTED_SQL, translatedQuery);
   }
+
+  @Test
+  public void testQueryNested() throws Exception {
+    String jsonQuery = Files.readString(TEST_FILES.resolve("query3.json"));
+
+    String expectedSql = String.format("SELECT * FROM %s, UNNEST(A) AS _A, UNNEST(_A.B) AS _B, " +
+            "UNNEST(_B.C) AS _C, UNNEST(_C.D) AS _D WHERE (_D.column = value)", TABLE);
+
+    Query query = objectMapper.readValue(jsonQuery, Query.class);
+    String translatedQuery = QueryTranslator.sql(TABLE, query);
+
+    assertEquals(expectedSql, translatedQuery);
+  }
 }

--- a/src/test/resources/query/query3.json
+++ b/src/test/resources/query/query3.json
@@ -1,0 +1,11 @@
+{
+  "node_type": "=",
+  "l": {
+    "node_type": "column",
+    "value": "A.B.C.D.column"
+  },
+  "r": {
+    "node_type": "unquoted",
+    "value": "value"
+  }
+}


### PR DESCRIPTION
The `boolean-query` endpoint will now support nested column names. Each nested name has a separate `UNNEST` clause in the `FROM` expression.

Fixes #38 