### PR TITLE
Fix issue with ambiguous field names

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,10 @@ the git-push script:
 ./misc/git-push.sh "Comment describing the change" 
 ```
 
-Note that will completely overwrite the previous code with the newly generated code.
+Notes
+- This will completely overwrite the previous code with the newly generated code.
+- The python package version uses the openapi version (property `info.version`). Be sure to update the openapi yaml
+version before generating a new python client, or the new client will have the same version.
 
 ## OpenAPI V3
 

--- a/src/main/java/bio/terra/cda/app/util/QueryTranslator.java
+++ b/src/main/java/bio/terra/cda/app/util/QueryTranslator.java
@@ -11,61 +11,85 @@ public class QueryTranslator {
   /**
    * Create a SQL query string given a table (or subquery) and a Query object.
    *
-   * @param table the table or subquery string to use as the first element of the FROM clause
+   * @param table the table to use as the first element of the FROM clause
    * @param query the Query object
    * @return a SQL query string
    */
   public static String sql(String table, Query query) {
-    if (query.getNodeType() == Query.NodeTypeEnum.SUBQUERY) {
-      // A SUBQUERY is built differently from other queries. The FROM clause is the SQL version of
-      // the query in R, instead of using table. The L subtree is now the top level query.
-      return sql(String.format("(%s)", sql(table, query.getR())), query.getL());
-    }
-    var fromClause =
-        Stream.concat(Stream.of(table), getUnnestColumns(query).distinct())
-            .collect(Collectors.joining(", "));
-
-    var condition = queryString(query);
-    return String.format("SELECT * FROM %s WHERE %s", fromClause, condition);
+    return new SqlGenerator(table, query).generate();
   }
 
-  private static Stream<String> getUnnestColumns(Query query) {
-    switch (query.getNodeType()) {
-      case QUOTED:
-      case UNQUOTED:
-      case NOT:
-        return Stream.empty();
-      case COLUMN:
-        var parts = query.getValue().split("\\.");
-        return IntStream.range(0, parts.length - 1)
-            .mapToObj(
-                i ->
-                    i == 0
-                        ? String.format("UNNEST(%1$s) AS _%1$s", parts[i])
-                        : String.format("UNNEST(_%1$s.%2$s) AS _%2$s", parts[i - 1], parts[i]));
-      default:
-        return Stream.concat(getUnnestColumns(query.getL()), getUnnestColumns(query.getR()));
-    }
-  }
+  // A convenience class to avoid having to pass 'table' around to all the methods.
+  private static class SqlGenerator {
+    final String qualifiedTable;
+    final Query rootQuery;
+    final String table;
 
-  private static String queryString(Query query) {
-    switch (query.getNodeType()) {
-      case QUOTED:
-        return String.format("'%s'", query.getValue());
-      case UNQUOTED:
-        return String.format("%s", query.getValue());
-      case COLUMN:
-        var parts = query.getValue().split("\\.");
-        if (parts.length > 1) {
-          return String.format("_%s.%s", parts[parts.length - 2], parts[parts.length - 1]);
-        }
-        return query.getValue();
-      case NOT:
-        return String.format("(%s %s)", query.getNodeType(), queryString(query.getL()));
-      default:
-        return String.format(
-            "(%s %s %s)",
-            queryString(query.getL()), query.getNodeType(), queryString(query.getR()));
+    private SqlGenerator(String qualifiedTable, Query rootQuery) {
+      this.qualifiedTable = qualifiedTable;
+      this.rootQuery = rootQuery;
+      int dotPos = qualifiedTable.lastIndexOf('.');
+      this.table = dotPos == -1 ? qualifiedTable : qualifiedTable.substring(dotPos + 1);
+    }
+
+    private String generate() {
+      return sql(qualifiedTable, rootQuery);
+    }
+
+    private String sql(String tableOrSubClause, Query query) {
+      if (query.getNodeType() == Query.NodeTypeEnum.SUBQUERY) {
+        // A SUBQUERY is built differently from other queries. The FROM clause is the SQL version of
+        // the right subtree, instead of using table. The left subtree is now the top level query.
+        return sql(String.format("(%s)", sql(tableOrSubClause, query.getR())), query.getL());
+      }
+      var fromClause =
+          Stream.concat(Stream.of(tableOrSubClause), getUnnestColumns(query).distinct())
+              .collect(Collectors.joining(", "));
+
+      var condition = queryString(query);
+      return String.format("SELECT * FROM %s WHERE %s", fromClause, condition);
+    }
+
+    private Stream<String> getUnnestColumns(Query query) {
+      switch (query.getNodeType()) {
+        case QUOTED:
+        case UNQUOTED:
+        case NOT:
+          return Stream.empty();
+        case COLUMN:
+          var parts = query.getValue().split("\\.");
+          return IntStream.range(0, parts.length - 1)
+              .mapToObj(
+                  i ->
+                      i == 0
+                          ? String.format("UNNEST(%1$s) AS _%1$s", parts[i])
+                          : String.format("UNNEST(_%1$s.%2$s) AS _%2$s", parts[i - 1], parts[i]));
+        default:
+          return Stream.concat(getUnnestColumns(query.getL()), getUnnestColumns(query.getR()));
+      }
+    }
+
+    private String queryString(Query query) {
+      switch (query.getNodeType()) {
+        case QUOTED:
+          return String.format("'%s'", query.getValue());
+        case UNQUOTED:
+          return String.format("%s", query.getValue());
+        case COLUMN:
+          var parts = query.getValue().split("\\.");
+          if (parts.length > 1) {
+            return String.format("_%s.%s", parts[parts.length - 2], parts[parts.length - 1]);
+          }
+          // Top level fields must be scoped by the table name, otherwise they could conflict with
+          // unnested fields.
+          return String.format("%s.%s", table, query.getValue());
+        case NOT:
+          return String.format("(%s %s)", query.getNodeType(), queryString(query.getL()));
+        default:
+          return String.format(
+              "(%s %s %s)",
+              queryString(query.getL()), query.getNodeType(), queryString(query.getR()));
+      }
     }
   }
 }

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   description: API definition for the CDA
-  version: 1.0.0-rc.1
+  version: 1.0.1
   title: CDA API
   license:
     name: Apache 2.0

--- a/src/test/java/bio/terra/cda/app/controller/QueryApiControllerTest.java
+++ b/src/test/java/bio/terra/cda/app/controller/QueryApiControllerTest.java
@@ -36,7 +36,7 @@ class QueryApiControllerTest {
 
   private void callQueryApi(boolean dryRun) throws Exception {
     var query = new Query().nodeType(Query.NodeTypeEnum.COLUMN).value("test");
-    var expected = "SELECT * FROM TABLE.v0 WHERE test";
+    var expected = "SELECT * FROM TABLE.v0 WHERE v0.test";
 
     var post =
         post("/api/v1/boolean-query/v0?dryRun={dryRun}", dryRun)

--- a/src/test/resources/query/query-ambiguous.json
+++ b/src/test/resources/query/query-ambiguous.json
@@ -1,0 +1,25 @@
+{
+  "node_type": "SUBQUERY",
+  "l": {
+    "node_type": "=",
+    "l": {
+      "node_type": "column",
+      "value": "id"
+    },
+    "r": {
+      "node_type": "quoted",
+      "value": "this"
+    }
+  },
+  "r": {
+    "node_type": "=",
+    "l": {
+      "node_type": "column",
+      "value": "id"
+    },
+    "r": {
+      "node_type": "quoted",
+      "value": "that"
+    }
+  }
+}


### PR DESCRIPTION
Fix issue where a top level field could be made ambiguous by unnesting. Now top level fields are qualified using the table name.

Also added a fix so the generated python client will have an updated version.