### PR TITLE
A few API cleanups

### DIFF
--- a/src/main/java/bio/terra/cda/app/controller/MetaApiController.java
+++ b/src/main/java/bio/terra/cda/app/controller/MetaApiController.java
@@ -1,14 +1,33 @@
 package bio.terra.cda.app.controller;
 
+import bio.terra.cda.app.configuration.ApplicationConfiguration;
 import bio.terra.cda.generated.controller.MetaApi;
+import bio.terra.cda.generated.model.DatasetDescription;
+import bio.terra.cda.generated.model.DatasetInfo;
+import bio.terra.cda.generated.model.Model;
 import bio.terra.cda.generated.model.SystemStatus;
 import bio.terra.cda.generated.model.SystemStatusSystems;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
 @Controller
 public class MetaApiController implements MetaApi {
+
+  private final ApplicationConfiguration applicationConfiguration;
+
+  @Autowired
+  public MetaApiController(ApplicationConfiguration applicationConfiguration) {
+    this.applicationConfiguration = applicationConfiguration;
+  }
 
   @Override
   public ResponseEntity<SystemStatus> serviceStatus() {
@@ -21,5 +40,34 @@ public class MetaApiController implements MetaApi {
         new SystemStatus().ok(true).putSystemsItem("BigQuery", otherSystemStatus);
 
     return new ResponseEntity<>(systemStatus, httpStatus);
+  }
+
+  private String getDatasetVersion() {
+    var bqTable = applicationConfiguration.getBqTable();
+    int lastDot = bqTable.lastIndexOf('.');
+    // Currently, the table name name in bigquery is the dataset "version".
+    return applicationConfiguration.getBqTable().substring(lastDot + 1);
+  }
+
+  // For now, the dataset description is hardcoded. In the future, it will probably be read from a
+  // table in bigquery.
+  private DatasetDescription createDescription() {
+    var firstOfMarch = OffsetDateTime.of(LocalDate.of(2021, 3, 1), LocalTime.MIN, ZoneOffset.UTC).toString();
+    return new DatasetDescription()
+        .addDatasetsItem(new DatasetInfo().version(getDatasetVersion()).source("PDC and GDC").date(firstOfMarch))
+        .cdaVersion("MVP")
+        .notes("CDA MVP release")
+        .releaseDate(firstOfMarch)
+        .cdaModel(new Model());
+  }
+
+  @Override
+  public ResponseEntity<List<DatasetDescription>> allReleaseNotes() {
+    return ResponseEntity.ok(Collections.singletonList(createDescription()));
+  }
+
+  @Override
+  public ResponseEntity<DatasetDescription> latestReleaseNotes() {
+    return ResponseEntity.ok(createDescription());
   }
 }

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -150,6 +150,7 @@ components:
       required: true
       schema:
         type: string
+        default: v2
       description: Dataset version
     ResultOffset:
       in: query
@@ -229,7 +230,6 @@ components:
 
     DateType:
       type: string
-      format: date-time
 
     DatasetInfo:
       type: object


### PR DESCRIPTION
- add stub implementations of `dataset-description` endpoints
- use plain string for date/time objects to fix date/date formatting in response
- use v2 as the default dataset version in the swagger UI