### PR TITLE
flip order of server list in swagger page, so external URL is listed first

### DIFF
--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -8,8 +8,8 @@ info:
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
 
 servers:
-  - url: http://localhost:8080
   - url: https://cda.cda-dev.broadinstitute.org
+  - url: http://localhost:8080
 
 tags:
   - name: query


### PR DESCRIPTION
Fixes #54 