### PR TITLE
Update version 0.0.17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = 'bio.terra.cda'
-version = '0.0.16'
+version = '0.0.17'
 sourceCompatibility = JavaVersion.VERSION_11
 
 repositories {


### PR DESCRIPTION
Includes hotfixes for 
- broken binder path
- unique values system filter was not working as designed in Jupyter Notebook
- System status endpoint for checking that BigQuery cda_mvp table is reachable from Swagger.
