### PR TITLE
sonarcloud.io scans enabled on tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,5 +13,23 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
+    - name: Cache SonarCloud packages
+      uses: actions/cache@v1
+      with:
+        path: ~/.sonar/cache
+        key: ${{ runner.os }}-sonar
+        restore-keys: ${{ runner.os }}-sonar
+    - name: Cache Gradle packages
+      uses: actions/cache@v1
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: ${{ runner.os }}-gradle
+    - name: Build and analyze
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      run: ./gradlew build sonarqube --info
     - name: Run tests
       run: ./gradlew test --scan
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,11 +25,11 @@ jobs:
         path: ~/.gradle/caches
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle
-    - name: Build and analyze
+    - name: Run tests
+      run: ./gradlew test --scan
+    - name: Run SonarQube scan
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      run: ./gradlew build sonarqube --info
-    - name: Run tests
-      run: ./gradlew test --scan
+      run: ./gradlew sonarqube --info
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ plugins {
 	id 'com.google.cloud.tools.jib' version '2.8.0'
 	id 'org.openapi.generator' version '5.1.1'
 	id 'com.diffplug.spotless' version '5.12.4'
+  	id "org.sonarqube" version "3.3"
 }
 
 group = 'bio.terra.cda'
@@ -155,4 +156,12 @@ if (hasProperty('buildScan')) {
 		termsOfServiceUrl = 'https://gradle.com/terms-of-service'
 		termsOfServiceAgree = 'yes'
 	}
+}
+
+sonarqube {
+  properties {
+    property "sonar.projectKey", "CancerDataAggregator_cda-service"
+    property "sonar.organization", "cancerdataaggregator"
+    property "sonar.host.url", "https://sonarcloud.io"
+  }
 }


### PR DESCRIPTION
After discussion on Slack, I have set up SonarQube static analysis using sonarcloud.io on the tests workflow.

Y'all may wish to set up the scan in a different workflow or on different events though doing them early and often is a good practice.