### PR TITLE
Add AppSec Trivy scanner

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -1,0 +1,35 @@
+name: dsp-appsec-trivy
+on: [pull_request]
+
+jobs:
+  appsec-trivy:
+    # Parse Dockerfile and build, scan image if a "blessed" base image is not used
+    name: DSP AppSec Trivy check
+    runs-on: ubuntu-latest
+    env:
+      # only used to name the image for this scan; it is not pushed anywhere
+      image: databiosphere/terra-external-credentials-manager
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - name: Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: gradle-
+
+      - name: Build image locally with Jib
+        run: |
+          ./gradlew jibDockerBuild --image="${image}"
+
+      - uses: broadinstitute/dsp-appsec-trivy-action@v1
+        with:
+          image: ${{ env.image }}


### PR DESCRIPTION
This PR adds [DSP AppSec Trivy GitHub Action](https://github.com/broadinstitute/dsp-appsec-trivy-action) for the Docker image.

The action will run on every PR and give you feedback if the Docker image contains critical OS vulnerabilities.

This is packaged as a standalone workflow so it doesn't break your other workflows, but if you'd like to integrate it into another workflow instead, please let us know.