### PR TITLE
CD-206 add http response headers for XSS protection

### DIFF
--- a/src/main/java/bio/terra/cda/app/filters/AddResponseHeaderFilter.java
+++ b/src/main/java/bio/terra/cda/app/filters/AddResponseHeaderFilter.java
@@ -1,0 +1,22 @@
+package bio.terra.cda.app.filters;
+
+import javax.servlet.*;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@WebFilter("/api/*")
+public class AddResponseHeaderFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response,
+                         FilterChain chain) throws IOException, ServletException {
+        HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+        httpServletResponse.setHeader(
+                "X-XSS-Protection", "1; mode=block");
+        httpServletResponse.setHeader(
+                "X-Content-Type-Options", "nosniff");
+        chain.doFilter(request, response);
+    }
+
+}


### PR DESCRIPTION
Add XSS protection to Response Headers at the request of InfoSec

How-To-Test:
1. Spin up the SpringBoot App using bootRun (Developers only) Testers should visit the integration swagger.
2. Open up Developer Tools in your WebBrowser / Network tab
3. Open the Swagger API and exercise the columns endpoint.
4. There should be 2 additional response headers X-XSS-Protection: 1; mode=block and
X-Content-Type-Options: nosniff