### PR TITLE
refactor how file counts are grabbed

### DIFF
--- a/src/main/java/bio/terra/cda/app/operators/In.java
+++ b/src/main/java/bio/terra/cda/app/operators/In.java
@@ -2,7 +2,6 @@ package bio.terra.cda.app.operators;
 
 import bio.terra.cda.app.util.TableSchema;
 import bio.terra.cda.generated.model.Query;
-
 import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -14,15 +13,17 @@ public class In extends SingleSidedOperator {
       throws IllegalArgumentException {
     String right = ((BasicOperator) getR()).queryString(table, tableSchemaMap);
     if (right.contains("[") || right.contains("(")) {
-      right = Arrays.stream(
-                right.substring(1, right.length() - 1).replace("\"", "'").split(",")
-              ).map(value -> {
-                if (value.contains("'")) {
-                  return String.format("UPPER(%s)", value);
-                }
+      right =
+          Arrays.stream(right.substring(1, right.length() - 1).replace("\"", "'").split(","))
+              .map(
+                  value -> {
+                    if (value.contains("'")) {
+                      return String.format("UPPER(%s)", value);
+                    }
 
-                return value;
-              }).collect(Collectors.joining(", "));
+                    return value;
+                  })
+              .collect(Collectors.joining(", "));
     } else {
       throw new IllegalArgumentException("To use IN you need to add [ or (");
     }

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -220,7 +220,7 @@ paths:
         - query
 
       parameters:
-        - $ref: "#/components/parameters/DatasetVersion"
+        - $ref: "#/components/parameters/FileDatasetVersion"
         - in: query
           description: If true, don't run the query, only generate and return it.
           name: dryRun
@@ -249,7 +249,7 @@ paths:
         - query
 
       parameters:
-        - $ref: "#/components/parameters/DatasetVersion"
+        - $ref: "#/components/parameters/FileDatasetVersion"
         - in: query
           description: If true, don't run the query, only generate and return it.
           name: dryRun
@@ -279,6 +279,14 @@ components:
       schema:
         type: string
         default: all_v3_0_subjects_meta
+      description: Dataset version
+    FileDatasetVersion:
+      in: path
+      name: version
+      required: true
+      schema:
+        type: string
+        default: all_v3_0_Files
       description: Dataset version
     SystemValue:
       in: query


### PR DESCRIPTION
The endpoint global-counts was not counting files correctly. Modified to only count ResearchSubject, Subject and Specimen entities that match the identifiers from the file.