### PR TITLE
Update Image Version Bump Workflow To Prevent Build Failures

### DIFF
--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -19,8 +19,7 @@ jobs:
       uses: actions/checkout@master
     - name: Bump version and push tag
       id: tag
-      uses: databiosphere/github-actions/actions/bumper@bumper-0.0.4
-      env:
+      uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
         DEFAULT_BUMP: patch
         GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
         RELEASE_BRANCHES: master

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -1,7 +1,6 @@
 name: Tag, Build, and Push Image
 
 on:
-  pull_request:
   push:
     branches:
     - master

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Bump version and push tag
       id: tag
       uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
-      with:
+      env:
         DEFAULT_BUMP: patch
         GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
         RELEASE_BRANCHES: master

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -20,6 +20,7 @@ jobs:
     - name: Bump version and push tag
       id: tag
       uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
+      with:
         DEFAULT_BUMP: patch
         GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
         RELEASE_BRANCHES: master

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -1,6 +1,7 @@
 name: Tag, Build, and Push Image
 
 on:
+  pull_request:
   push:
     branches:
     - master


### PR DESCRIPTION
I noticed that [this run](https://github.com/CancerDataAggregator/cda-service/runs/6993566813?check_suite_focus=true) failed to build and push a new cda image. This was due to a bug in git in that version of our image version bumper github action. I updated the action to latest, and that resolved the issue.