### PR TITLE
remove servers dropdown, testing only feature

### DIFF
--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -7,11 +7,12 @@ info:
     name: Apache 2.0
     url: "http://www.apache.org/licenses/LICENSE-2.0.html"
 
-servers:
-  - url: https://cancerdata.dsde-dev.broadinstitute.org
-  - url: https://cda.cda-dev.broadinstitute.org
-  - url: http://localhost:8080
-  - url: http://35.192.60.10:8080
+# testing only
+#servers:
+#  - url: https://cancerdata.dsde-dev.broadinstitute.org
+#  - url: https://cda.cda-dev.broadinstitute.org
+#  - url: http://localhost:8080
+#  - url: http://35.192.60.10:8080
 
 tags:
   - name: query


### PR DESCRIPTION
Servers dropdown should not exist on our servers, especially in production.