### PR TITLE
Update to validation of queries

### DIFF
--- a/src/main/java/bio/terra/cda/app/builders/QueryFieldBuilder.java
+++ b/src/main/java/bio/terra/cda/app/builders/QueryFieldBuilder.java
@@ -5,6 +5,7 @@ import bio.terra.cda.app.util.SqlUtil;
 import bio.terra.cda.app.util.TableSchema;
 import com.google.cloud.bigquery.Field;
 import java.util.Map;
+import java.util.Objects;
 
 public class QueryFieldBuilder {
   private final Map<String, TableSchema.SchemaDefinition> baseSchema;
@@ -32,6 +33,12 @@ public class QueryFieldBuilder {
     String[] parts = SqlUtil.getParts(realPath);
     TableSchema.SchemaDefinition schemaDefinition =
         (fileField ? this.fileSchema : this.baseSchema).get(realPath);
+
+    if (Objects.isNull(schemaDefinition)) {
+      throw new IllegalArgumentException(
+          String.format("Column %s does not exist on table %s", path, this.table));
+    }
+
     String alias = SqlUtil.getAlias(parts.length - 1, parts);
     String columnText = getColumnText(schemaDefinition, parts, alias, fileField);
 

--- a/src/main/java/bio/terra/cda/app/operators/BasicOperator.java
+++ b/src/main/java/bio/terra/cda/app/operators/BasicOperator.java
@@ -24,13 +24,8 @@ public class BasicOperator extends Query {
   }
 
   protected void addUnnests(QueryContext ctx) {
-    try {
-      ctx.addUnnests(
-          ctx.getUnnestBuilder()
-              .fromQueryField(ctx.getQueryFieldBuilder().fromPath(getValue()), true));
-    } catch (NullPointerException e) {
-      throw new IllegalArgumentException(
-          String.format("Column %s does not exist on table %s", getValue(), ctx.getTable()));
-    }
+    ctx.addUnnests(
+        ctx.getUnnestBuilder()
+            .fromQueryField(ctx.getQueryFieldBuilder().fromPath(getValue()), true));
   }
 }

--- a/src/test/java/bio/terra/cda/app/helpers/QueryFileReader.java
+++ b/src/test/java/bio/terra/cda/app/helpers/QueryFileReader.java
@@ -1,0 +1,24 @@
+package bio.terra.cda.app.helpers;
+
+import bio.terra.cda.app.operators.QueryModule;
+import bio.terra.cda.generated.model.Query;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class QueryFileReader {
+    static final Path TEST_FILES = Paths.get("src/test/resources/query");
+
+    private static final ObjectMapper objectMapper = new ObjectMapper().registerModule(new QueryModule());
+
+    private QueryFileReader() { }
+
+    public static Query getQueryFromFile(String fileName) throws IOException {
+        String jsonQuery = Files.readString(TEST_FILES.resolve(fileName));
+
+        return objectMapper.readValue(jsonQuery, Query.class);
+    }
+}

--- a/src/test/java/bio/terra/cda/app/helpers/QueryHelper.java
+++ b/src/test/java/bio/terra/cda/app/helpers/QueryHelper.java
@@ -1,0 +1,27 @@
+package bio.terra.cda.app.helpers;
+
+import bio.terra.cda.app.builders.PartitionBuilder;
+import bio.terra.cda.app.builders.QueryFieldBuilder;
+import bio.terra.cda.app.builders.SelectBuilder;
+import bio.terra.cda.app.builders.UnnestBuilder;
+import bio.terra.cda.app.util.QueryContext;
+import bio.terra.cda.app.util.TableSchema;
+
+import java.io.IOException;
+
+public class QueryHelper {
+    private QueryHelper() { }
+
+    public static QueryContext getNewQueryContext(
+            String table, String fileTable, String entity, String project, boolean includeSelect) throws IOException {
+        var schemas = new Schemas.SchemaBuilder(table, fileTable).build();
+        var entitySchema = TableSchema.getDefinitionByName(schemas.getSchema(), entity);
+
+        return new QueryContext(table, project)
+                .setIncludeSelect(includeSelect)
+                .setQueryFieldBuilder(new QueryFieldBuilder(schemas.getSchemaMap(), schemas.getFileSchemaMap(), table, fileTable))
+                .setUnnestBuilder(new UnnestBuilder(table, fileTable, entitySchema.getParts(), project))
+                .setPartitionBuilder(new PartitionBuilder(fileTable))
+                .setSelectBuilder(new SelectBuilder(table, fileTable));
+    }
+}

--- a/src/test/java/bio/terra/cda/app/helpers/Schemas.java
+++ b/src/test/java/bio/terra/cda/app/helpers/Schemas.java
@@ -1,0 +1,61 @@
+package bio.terra.cda.app.helpers;
+
+import bio.terra.cda.app.util.TableSchema;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class Schemas {
+    private final Map<String, TableSchema.SchemaDefinition> schemaMap;
+    private final Map<String, TableSchema.SchemaDefinition> fileSchemaMap;
+    private final List<TableSchema.SchemaDefinition> schema;
+    private final List<TableSchema.SchemaDefinition> fileSchema;
+
+    private Schemas(
+            Map<String, TableSchema.SchemaDefinition> schemaMap,
+            Map<String, TableSchema.SchemaDefinition> fileSchemaMap,
+            List<TableSchema.SchemaDefinition> schema,
+            List<TableSchema.SchemaDefinition> fileSchema) {
+        this.schemaMap = schemaMap;
+        this.fileSchemaMap = fileSchemaMap;
+        this.schema = schema;
+        this.fileSchema = fileSchema;
+    }
+
+    public Map<String, TableSchema.SchemaDefinition> getSchemaMap() {
+        return schemaMap;
+    }
+
+    public Map<String, TableSchema.SchemaDefinition> getFileSchemaMap() {
+        return fileSchemaMap;
+    }
+
+    public List<TableSchema.SchemaDefinition> getSchema() {
+        return schema;
+    }
+
+    public List<TableSchema.SchemaDefinition> getFileSchema() {
+        return fileSchema;
+    }
+
+    public static class SchemaBuilder {
+        private final String table;
+        private final String fileTable;
+
+        public SchemaBuilder(String table, String fileTable) {
+            this.table = table;
+            this.fileTable = fileTable;
+        }
+
+        public Schemas build() throws IOException {
+            var tableSchema = TableSchema.getSchema(this.table);
+            var fileTableSchema = TableSchema.getSchema(this.fileTable);
+            return new Schemas(
+                    TableSchema.buildSchemaMap(tableSchema),
+                    TableSchema.buildSchemaMap(fileTableSchema),
+                    tableSchema,
+                    fileTableSchema);
+        }
+    }
+}

--- a/src/test/java/bio/terra/cda/app/operators/BasicOperatorTest.java
+++ b/src/test/java/bio/terra/cda/app/operators/BasicOperatorTest.java
@@ -1,0 +1,72 @@
+package bio.terra.cda.app.operators;
+
+import bio.terra.cda.app.helpers.QueryFileReader;
+import bio.terra.cda.app.helpers.QueryHelper;
+import bio.terra.cda.app.util.QueryContext;
+import bio.terra.cda.app.util.SqlUtil;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class BasicOperatorTest {
+    @Test
+    void testInvalidColumn() throws IOException {
+        BasicOperator query = (BasicOperator) QueryFileReader.getQueryFromFile("query-invalid-column.json");
+
+        QueryContext ctx = QueryHelper.getNewQueryContext(
+                "all_Subjects_v3_0_final", "all_Files_v3_0_final", "Subject", "project", true);
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> query.buildQuery(ctx),
+            "Expected query to throw IllegalArgumentException but didn't"
+        );
+    }
+
+    @Test
+    void testEqualsQuoted() throws IOException {
+        BasicOperator query = (BasicOperator) QueryFileReader.getQueryFromFile("query-equals-quoted.json");
+
+        QueryContext ctx = QueryHelper.getNewQueryContext(
+                "all_Subjects_v3_0_final", "all_Files_v3_0_final", "Subject", "project", true);
+
+        String whereClause = query.buildQuery(ctx);
+
+        assertEquals(0, ctx.getUnnests().size());
+        assertEquals(0, ctx.getPartitions().size());
+        assertEquals("(IFNULL(UPPER(all_Subjects_v3_0_final.id), '') = UPPER('test_id'))", whereClause);
+    }
+
+    @Test
+    void testAndOr() throws IOException {
+        BasicOperator query = (BasicOperator) QueryFileReader.getQueryFromFile("query-kidney.json");
+
+        QueryContext ctx = QueryHelper.getNewQueryContext(
+                "all_Subjects_v3_0_final", "all_Files_v3_0_final", "Subject", "project", true);
+
+        String whereClause = query.buildQuery(ctx);
+
+        assertEquals(2, ctx.getUnnests().size());
+        assertEquals(0, ctx.getPartitions().size());
+        assertEquals("(((IFNULL(UPPER(_ResearchSubject_Diagnosis.stage), '') = UPPER('Stage I')) OR (IFNULL(UPPER(_ResearchSubject_Diagnosis.stage), '') = UPPER('Stage II'))) AND (IFNULL(UPPER(_ResearchSubject.primary_diagnosis_site), '') = UPPER('Kidney')))", whereClause);
+
+        QueryContext ResearchSubjectContext = QueryHelper.getNewQueryContext(
+                "all_Subjects_v3_0_final", "all_Files_v3_0_final", "ResearchSubject", "project", true);
+
+        String rsWhere = query.buildQuery(ResearchSubjectContext);
+
+        assertEquals(2, ResearchSubjectContext.getUnnests().size());
+
+        ResearchSubjectContext.getUnnests().forEach(unnest -> {
+            if (unnest.getPath().equals("all_Subjects_v3_0_final.ResearchSubject")) {
+                assertEquals(SqlUtil.JoinType.INNER, unnest.getJoinType());
+            } else {
+                assertEquals(SqlUtil.JoinType.LEFT, unnest.getJoinType());
+                assertEquals("_ResearchSubject.Diagnosis", unnest.getPath());
+            }
+        });
+    }
+}

--- a/src/test/java/bio/terra/cda/app/operators/SelectTest.java
+++ b/src/test/java/bio/terra/cda/app/operators/SelectTest.java
@@ -1,0 +1,47 @@
+package bio.terra.cda.app.operators;
+
+import bio.terra.cda.app.helpers.QueryFileReader;
+import bio.terra.cda.app.helpers.QueryHelper;
+import bio.terra.cda.app.util.QueryContext;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class SelectTest {
+    @Test
+    void testInvalidColumn() throws IOException {
+        BasicOperator query = (BasicOperator) QueryFileReader.getQueryFromFile("query-invalid-select-column.json");
+
+        QueryContext ctx = QueryHelper.getNewQueryContext(
+                "all_Subjects_v3_0_final", "all_Files_v3_0_final", "Subject", "project", true);
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> query.buildQuery(ctx),
+                "Expected query to throw IllegalArgumentException but didn't"
+        );
+    }
+
+    @Test
+    void testSelectMultipleColumnsSameNestedObj() throws  IOException {
+        BasicOperator query = (BasicOperator) QueryFileReader.getQueryFromFile("query-select-easy.json");
+
+        QueryContext ctx = QueryHelper.getNewQueryContext(
+                "all_Subjects_v3_0_final", "all_Files_v3_0_final", "Subject", "project", true);
+
+        String whereClause = query.buildQuery(ctx);
+
+        assertEquals(1, ctx.getUnnests().size());
+        assertEquals(3, ctx.getSelect().size());
+
+        if (ctx.getPartitions()
+                .stream()
+                .noneMatch(partition -> partition.toString().equals("_ResearchSubject.id"))) {
+            fail();
+        }
+    }
+}

--- a/src/test/resources/query/query-equals-quoted.json
+++ b/src/test/resources/query/query-equals-quoted.json
@@ -1,0 +1,11 @@
+{
+  "node_type": "=",
+  "l": {
+    "node_type": "column",
+    "value": "id"
+  },
+  "r": {
+    "node_type": "quoted",
+    "value": "test_id"
+  }
+}

--- a/src/test/resources/query/query-invalid-column.json
+++ b/src/test/resources/query/query-invalid-column.json
@@ -1,0 +1,11 @@
+{
+  "node_type": "=",
+  "l": {
+    "node_type": "column",
+    "value": "not_real"
+  },
+  "r": {
+    "node_type": "quoted",
+    "value": "shouldn't matter"
+  }
+}

--- a/src/test/resources/query/query-invalid-select-column.json
+++ b/src/test/resources/query/query-invalid-select-column.json
@@ -1,0 +1,18 @@
+{
+  "node_type": "SELECT",
+  "l": {
+    "node_type": "SELECTVALUES",
+    "value": "id, not_a_column"
+  },
+  "r": {
+    "node_type": "=",
+    "l": {
+      "node_type": "column",
+      "value": "id"
+    },
+    "r": {
+      "node_type": "quoted",
+      "value": "test"
+    }
+  }
+}

--- a/src/test/resources/query/query-select-easy.json
+++ b/src/test/resources/query/query-select-easy.json
@@ -1,0 +1,18 @@
+{
+  "node_type": "SELECT",
+  "l": {
+    "node_type": "SELECTVALUES",
+    "value": "id, ResearchSubject.primary_diagnosis_site, ResearchSubject.primary_diagnosis_condition"
+  },
+  "r": {
+    "node_type": "=",
+    "l": {
+      "node_type": "column",
+      "value": "id"
+    },
+    "r": {
+      "node_type": "quoted",
+      "value": "test"
+    }
+  }
+}

--- a/src/test/resources/schema/all_Files_v3_0_final.json
+++ b/src/test/resources/schema/all_Files_v3_0_final.json
@@ -1,0 +1,480 @@
+[
+  {
+    "description": "The 'logical' identifier of the entity in the repository, e.g. a UUID.  This 'id' is unique within a given system. The identified entity may have a different 'id' in a different system.",
+    "mode": "REQUIRED",
+    "name": "id",
+    "type": "STRING"
+  },
+  {
+    "description": "A 'business' identifier  or accession number for the entity, typically as provided by an external system or authority, that persists across implementing systems  (i.e. a  'logical' identifier). ",
+    "fields": [
+      {
+        "description": "The system or namespace that defines the identifier.",
+        "mode": "NULLABLE",
+        "name": "system",
+        "type": "STRING"
+      },
+      {
+        "description": "The value of the identifier, as defined by the system.",
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "identifier",
+    "type": "RECORD"
+  },
+  {
+    "description": "Short name or abbreviation for dataset. Maps to rdfs:label.",
+    "mode": "NULLABLE",
+    "name": "label",
+    "type": "STRING"
+  },
+  {
+    "description": "Broad categorization of the contents of the data file.",
+    "mode": "NULLABLE",
+    "name": "data_category",
+    "type": "STRING"
+  },
+  {
+    "description": "Specific content type of the data file.",
+    "mode": "NULLABLE",
+    "name": "data_type",
+    "type": "STRING"
+  },
+  {
+    "description": "Format of the data files.",
+    "mode": "NULLABLE",
+    "name": "file_format",
+    "type": "STRING"
+  },
+  {
+    "description": "A reference to the Project(s) of which this ResearchSubject is a member. The associated_project may be embedded using the $ref definition or may be a reference to the id for the Project - or a URI expressed as a string to an existing entity.",
+    "mode": "NULLABLE",
+    "name": "associated_project",
+    "type": "STRING"
+  },
+  {
+    "description": "A string of characters used to identify a resource on the Data Repo Service(DRS).",
+    "mode": "NULLABLE",
+    "name": "drs_uri",
+    "type": "STRING"
+  },
+  {
+    "description": "Size of the file in bytes. Maps to dcat:byteSize.",
+    "mode": "NULLABLE",
+    "name": "byte_size",
+    "type": "INTEGER"
+  },
+  {
+    "description": "A digit representing the sum of the correct digits in a piece of stored or transmitted digital data, against which later comparisons can be made to detect errors in the data.",
+    "mode": "NULLABLE",
+    "name": "checksum",
+    "type": "STRING"
+  },
+  {
+    "description": "Data modality describes the biological nature of the information gathered as the result of an Activity, independent of the technology or methods used to produce the information.",
+    "mode": "NULLABLE",
+    "name": "data_modality",
+    "type": "STRING"
+  },
+  {
+    "description": "An imaging modality describes the imaging equipment and/or method used to acquire certain structural or functional information about the body. These include but are not limited to computed tomography (CT) and magnetic resonance imaging (MRI). Taken from the DICOM standard.",
+    "mode": "NULLABLE",
+    "name": "imaging_modality",
+    "type": "STRING"
+  },
+  {
+    "description": "The dbgap accession number for the project.",
+    "mode": "NULLABLE",
+    "name": "dbgap_accession_number",
+    "type": "STRING"
+  },
+  {
+    "description": "The 'logical' identifier of the series or grouping of imaging files in the system of record which the file is a part of.",
+    "mode": "NULLABLE",
+    "name": "imaging_series",
+    "type": "STRING"
+  },
+  {
+    "description": "A patient entity captures the study-independent metadata for research subjects. Human research subjects are usually not traceable to a particular person to protect the subject\u2019s privacy.",
+    "fields": [
+      {
+        "description": "The 'logical' identifier of the entity in the system of record, e.g. a UUID.  This 'id' is unique within a given system. The identified entity may have a different 'id' in a different system.",
+        "mode": "REQUIRED",
+        "name": "id",
+        "type": "STRING"
+      },
+      {
+        "description": "A 'business' identifier for the entity, typically as provided by an external system or authority, that persists across implementing systems  (i.e. a  'logical' identifier). Uses a specialized, complex 'Identifier' data type to capture information about the source of the business identifier - or a URI expressed as a string to an existing entity. ",
+        "fields": [
+          {
+            "description": "The system or namespace that defines the identifier.",
+            "mode": "NULLABLE",
+            "name": "system",
+            "type": "STRING"
+          },
+          {
+            "description": "The value of the identifier, as defined by the system.",
+            "mode": "NULLABLE",
+            "name": "value",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "identifier",
+        "type": "RECORD"
+      },
+      {
+        "description": "The taxonomic group (e.g. species) of the patient. For MVP, since taxonomy vocabulary is consistent between GDC and PDC, using text.  Ultimately, this will be a term returned by the vocabulary service.",
+        "mode": "NULLABLE",
+        "name": "species",
+        "type": "STRING"
+      },
+      {
+        "description": "The biologic character or quality that distinguishes male and female from one another as expressed by analysis of the person's gonadal, morphologic (internal and external), chromosomal, and hormonal characteristics.",
+        "mode": "NULLABLE",
+        "name": "sex",
+        "type": "STRING"
+      },
+      {
+        "description": "An arbitrary classification of a taxonomic group that is a division of a species. It usually arises as a consequence of geographical isolation within a species and is characterized by shared heredity, physical attributes and behavior, and in the case of humans, by common history, nationality, or geographic distribution. The provided values are based on the categories defined by the U.S. Office of Management and Business and used by the U.S. Census Bureau.",
+        "mode": "NULLABLE",
+        "name": "race",
+        "type": "STRING"
+      },
+      {
+        "description": "An individual's self-described social and cultural grouping, specifically whether an individual describes themselves as Hispanic or Latino. The provided values are based on the categories defined by the U.S. Office of Management and Business and used by the U.S. Census Bureau.",
+        "mode": "NULLABLE",
+        "name": "ethnicity",
+        "type": "STRING"
+      },
+      {
+        "description": "Number of days between the date used for index and the date from a person's date of birth represented as a calculated negative number of days.",
+        "mode": "NULLABLE",
+        "name": "days_to_birth",
+        "type": "INTEGER"
+      },
+      {
+        "description": "The list of Projects associated with the Subject.",
+        "mode": "REPEATED",
+        "name": "subject_associated_project",
+        "type": "STRING"
+      },
+      {
+        "description": "Coded value indicating the state or condition of being living or deceased; also includes the case where the vital status is unknown.",
+        "mode": "NULLABLE",
+        "name": "vital_status",
+        "type": "STRING"
+      },
+      {
+        "description": "Number of days between the date used for index and the date from a person's date of death represented as a calculated number of days.",
+        "mode": "NULLABLE",
+        "name": "days_to_death",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Coded value indicating the circumstance or condition that results in the death of the subject.",
+        "mode": "NULLABLE",
+        "name": "cause_of_death",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "Subject",
+    "type": "RECORD"
+  },
+  {
+    "description": "A research subject is the entity of interest in a specific research study or project, typically a human being or an animal, but can also be a device, group of humans or animals, or a tissue sample. Human research subjects are usually not traceable to a particular person to protect the subject\u2019s privacy.  This entity plays the role of the case_id in existing data.",
+    "fields": [
+      {
+        "description": "The 'logical' identifier of the entity in the system of record, e.g. a UUID.  This 'id' is unique within a given system. The identified entity may have a different 'id' in a different system. For CDA, this is case_id.",
+        "mode": "REQUIRED",
+        "name": "id",
+        "type": "STRING"
+      },
+      {
+        "description": "A 'business' identifier for the entity, typically as provided by an external system or authority, that persists across implementing systems  (i.e. a  'logical' identifier). Uses a specialized, complex 'Identifier' data type to capture information about the source of the business identifier - or a URI expressed as a string to an existing entity. ",
+        "fields": [
+          {
+            "description": "The system or namespace that defines the identifier.",
+            "mode": "NULLABLE",
+            "name": "system",
+            "type": "STRING"
+          },
+          {
+            "description": "The value of the identifier, as defined by the system.",
+            "mode": "NULLABLE",
+            "name": "value",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "identifier",
+        "type": "RECORD"
+      },
+      {
+        "description": "A reference to the Study(s) of which this ResearchSubject is a member.",
+        "mode": "NULLABLE",
+        "name": "member_of_research_project",
+        "type": "STRING"
+      },
+      {
+        "description": "The text term used to describe the type of malignant disease, as categorized by the World Health Organization's (WHO) International Classification of Diseases for Oncology (ICD-O).   This attribute represents the disease that qualified the subject for inclusion on the ResearchProject.",
+        "mode": "NULLABLE",
+        "name": "primary_diagnosis_condition",
+        "type": "STRING"
+      },
+      {
+        "description": "The text term used to describe the primary site of disease, as categorized by the World Health Organization's (WHO) International Classification of Diseases for Oncology (ICD-O). This categorization groups cases into general categories.  This attribute represents the primary site of disease that qualified the subject for inclusion on the ResearchProject.",
+        "mode": "NULLABLE",
+        "name": "primary_diagnosis_site",
+        "type": "STRING"
+      },
+      {
+        "description": "A collection of characteristics that describe an abnormal condition of the body as assessed at a point in time. May be used to capture information about neoplastic and non-neoplastic conditions.",
+        "fields": [
+          {
+            "description": "The 'logical' identifier of the entity in the repository, e.g. a UUID.  This 'id' is unique within a given system. The identified entity may have a different 'id' in a different system.",
+            "mode": "REQUIRED",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "description": "A 'business' identifier  or accession number for the entity, typically as provided by an external system or authority, that persists across implementing systems  (i.e. a  'logical' identifier). ",
+            "fields": [
+              {
+                "description": "The system or namespace that defines the identifier.",
+                "mode": "NULLABLE",
+                "name": "system",
+                "type": "STRING"
+              },
+              {
+                "description": "The value of the identifier, as defined by the system.",
+                "mode": "NULLABLE",
+                "name": "value",
+                "type": "STRING"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "identifier",
+            "type": "RECORD"
+          },
+          {
+            "description": "The diagnosis instance that qualified a subject for inclusion on a ResearchProject",
+            "mode": "NULLABLE",
+            "name": "primary_diagnosis",
+            "type": "STRING"
+          },
+          {
+            "description": "The age in days of the individual at the time of diagnosis",
+            "mode": "NULLABLE",
+            "name": "age_at_diagnosis",
+            "type": "INTEGER"
+          },
+          {
+            "description": "Code that represents the histology of the disease using the third edition of the International Classification of Diseases for Oncology, published in 2000, used principally in tumor and cancer registri",
+            "mode": "NULLABLE",
+            "name": "morphology",
+            "type": "STRING"
+          },
+          {
+            "description": "The extent of a cancer in the body. Staging is usually based on the size of the tumor, whether lymph nodes contain cancer, and whether the cancer has spread from the original site to other parts of the body.",
+            "mode": "NULLABLE",
+            "name": "stage",
+            "type": "STRING"
+          },
+          {
+            "description": "The degree of abnormality of cancer cells, a measure of differentiation, the extent to which cancer cells are similar in appearance and function to healthy cells of the same tissue type. The degree of differentiation often relates to the clinical behavior of the particular tumor. Based on the microscopic findings, tumor grade is commonly described by one of four degrees of severity. Histopathologic grade of a tumor may be used to plan treatment and estimate the future course, outcome, and overall prognosis of disease. Certain types of cancers, such as soft tissue sarcoma, primary brain tumors, lymphomas, and breast have special grading systems.",
+            "mode": "NULLABLE",
+            "name": "grade",
+            "type": "STRING"
+          },
+          {
+            "description": "The method used to confirm the patients malignant diagnosis",
+            "mode": "NULLABLE",
+            "name": "method_of_diagnosis",
+            "type": "STRING"
+          },
+          {
+            "description": "Represent medication administration or other treatment types.",
+            "fields": [
+              {
+                "description": "The 'logical' identifier of the entity in the repository, e.g. a UUID.  This 'id' is unique within a given system. The identified entity may have a different 'id' in a different system.",
+                "mode": "REQUIRED",
+                "name": "id",
+                "type": "STRING"
+              },
+              {
+                "description": "A 'business' identifier  or accession number for the entity, typically as provided by an external system or authority, that persists across implementing systems  (i.e. a  'logical' identifier). ",
+                "fields": [
+                  {
+                    "description": "The system or namespace that defines the identifier.",
+                    "mode": "NULLABLE",
+                    "name": "system",
+                    "type": "STRING"
+                  },
+                  {
+                    "description": "The value of the identifier, as defined by the system.",
+                    "mode": "NULLABLE",
+                    "name": "value",
+                    "type": "STRING"
+                  }
+                ],
+                "mode": "REPEATED",
+                "name": "identifier",
+                "type": "RECORD"
+              },
+              {
+                "description": "The treatment type including medication/therapeutics or other procedures.",
+                "mode": "NULLABLE",
+                "name": "treatment_type",
+                "type": "STRING"
+              },
+              {
+                "description": "The final outcome of the treatment.",
+                "mode": "NULLABLE",
+                "name": "treatment_outcome",
+                "type": "STRING"
+              },
+              {
+                "description": "The timepoint at which the treatment started.",
+                "mode": "NULLABLE",
+                "name": "days_to_treatment_start",
+                "type": "INTEGER"
+              },
+              {
+                "description": " The timepoint at which the treatment ended.",
+                "mode": "NULLABLE",
+                "name": "days_to_treatment_end",
+                "type": "INTEGER"
+              },
+              {
+                "description": "One or more therapeutic agents as part of this treatment.",
+                "mode": "NULLABLE",
+                "name": "therapeutic_agent",
+                "type": "STRING"
+              },
+              {
+                "description": "The anatomical site that the treatment targets.",
+                "mode": "NULLABLE",
+                "name": "treatment_anatomic_site",
+                "type": "STRING"
+              },
+              {
+                "description": "The effect of a treatment on the diagnosis or tumor.",
+                "mode": "NULLABLE",
+                "name": "treatment_effect",
+                "type": "STRING"
+              },
+              {
+                "description": "The reason the treatment ended.",
+                "mode": "NULLABLE",
+                "name": "treatment_end_reason",
+                "type": "STRING"
+              },
+              {
+                "description": "The number of treatment cycles the subject received.",
+                "mode": "NULLABLE",
+                "name": "number_of_cycles",
+                "type": "INTEGER"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "Treatment",
+            "type": "RECORD"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "Diagnosis",
+        "type": "RECORD"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "ResearchSubject",
+    "type": "RECORD"
+  },
+  {
+    "description": "Any material taken as a sample from a biological entity (living or dead), or from a physical object or the environment. Specimens are usually collected as an example of their kind, often for use in some investigation.",
+    "fields": [
+      {
+        "description": "The 'logical' identifier of the entity in the system of record, e.g. a UUID.  This 'id' is unique within a given system. The identified entity may have a different 'id' in a different system.",
+        "mode": "REQUIRED",
+        "name": "id",
+        "type": "STRING"
+      },
+      {
+        "description": "A 'business' identifier  or accession number for the entity, typically as provided by an external system or authority, that persists across implementing systems  (i.e. a  'logical' identifier). ",
+        "fields": [
+          {
+            "description": "The system or namespace that defines the identifier.",
+            "mode": "NULLABLE",
+            "name": "system",
+            "type": "STRING"
+          },
+          {
+            "description": "The value of the identifier, as defined by the system.",
+            "mode": "NULLABLE",
+            "name": "value",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "identifier",
+        "type": "RECORD"
+      },
+      {
+        "description": "The Project associated with the specimen.",
+        "mode": "NULLABLE",
+        "name": "associated_project",
+        "type": "STRING"
+      },
+      {
+        "description": "The number of days from the index date to either the date a sample was collected for a specific study or project, or the date a patient underwent a procedure (e.g. surgical resection) yielding a sample that was eventually used for research.",
+        "mode": "NULLABLE",
+        "name": "days_to_collection",
+        "type": "INTEGER"
+      },
+      {
+        "description": "The text term used to describe the type of malignant disease, as categorized by the World Health Organization's (WHO) International Classification of Diseases for Oncology (ICD-O).   This attribute represents the disease that qualified the subject for inclusion on the ResearchProject.",
+        "mode": "NULLABLE",
+        "name": "primary_disease_type",
+        "type": "STRING"
+      },
+      {
+        "description": "Per GDC Dictionary, the text term that represents the name of the primary disease site of the submitted tumor sample; recommend dropping tumor; biospecimen_anatomic_site.",
+        "mode": "NULLABLE",
+        "name": "anatomical_site",
+        "type": "STRING"
+      },
+      {
+        "description": "The general kind of material from which the specimen was derived, indicating the physical nature of the source material. ",
+        "mode": "NULLABLE",
+        "name": "source_material_type",
+        "type": "STRING"
+      },
+      {
+        "description": "The high-level type of the specimen, based on its how it has been derived from the original extracted sample. \n",
+        "mode": "NULLABLE",
+        "name": "specimen_type",
+        "type": "STRING"
+      },
+      {
+        "description": "A source/parent specimen from which this one was directly derived.",
+        "mode": "NULLABLE",
+        "name": "derived_from_specimen",
+        "type": "STRING"
+      },
+      {
+        "description": "The Patient/ResearchSubject, or Biologically Derived Materal (e.g. a cell line, tissue culture, organoid) from which the specimen was directly or indirectly derived.",
+        "mode": "NULLABLE",
+        "name": "derived_from_subject",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "Specimen",
+    "type": "RECORD"
+  }
+]

--- a/src/test/resources/schema/all_Subjects_v3_0_final.json
+++ b/src/test/resources/schema/all_Subjects_v3_0_final.json
@@ -1,0 +1,392 @@
+[
+  {
+    "description": "The 'logical' identifier of the entity in the system of record, e.g. a UUID.  This 'id' is unique within a given system. The identified entity may have a different 'id' in a different system.",
+    "mode": "REQUIRED",
+    "name": "id",
+    "type": "STRING"
+  },
+  {
+    "description": "A 'business' identifier for the entity, typically as provided by an external system or authority, that persists across implementing systems  (i.e. a  'logical' identifier). Uses a specialized, complex 'Identifier' data type to capture information about the source of the business identifier - or a URI expressed as a string to an existing entity. ",
+    "fields": [
+      {
+        "description": "The system or namespace that defines the identifier.",
+        "mode": "NULLABLE",
+        "name": "system",
+        "type": "STRING"
+      },
+      {
+        "description": "The value of the identifier, as defined by the system.",
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "identifier",
+    "type": "RECORD"
+  },
+  {
+    "description": "The taxonomic group (e.g. species) of the patient. For MVP, since taxonomy vocabulary is consistent between GDC and PDC, using text.  Ultimately, this will be a term returned by the vocabulary service.",
+    "mode": "NULLABLE",
+    "name": "species",
+    "type": "STRING"
+  },
+  {
+    "description": "The biologic character or quality that distinguishes male and female from one another as expressed by analysis of the person's gonadal, morphologic (internal and external), chromosomal, and hormonal characteristics.",
+    "mode": "NULLABLE",
+    "name": "sex",
+    "type": "STRING"
+  },
+  {
+    "description": "An arbitrary classification of a taxonomic group that is a division of a species. It usually arises as a consequence of geographical isolation within a species and is characterized by shared heredity, physical attributes and behavior, and in the case of humans, by common history, nationality, or geographic distribution. The provided values are based on the categories defined by the U.S. Office of Management and Business and used by the U.S. Census Bureau.",
+    "mode": "NULLABLE",
+    "name": "race",
+    "type": "STRING"
+  },
+  {
+    "description": "An individual's self-described social and cultural grouping, specifically whether an individual describes themselves as Hispanic or Latino. The provided values are based on the categories defined by the U.S. Office of Management and Business and used by the U.S. Census Bureau.",
+    "mode": "NULLABLE",
+    "name": "ethnicity",
+    "type": "STRING"
+  },
+  {
+    "description": "Number of days between the date used for index and the date from a person's date of birth represented as a calculated negative number of days.",
+    "mode": "NULLABLE",
+    "name": "days_to_birth",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The list of Projects associated with the Subject.",
+    "mode": "REPEATED",
+    "name": "subject_associated_project",
+    "type": "STRING"
+  },
+  {
+    "description": "Coded value indicating the state or condition of being living or deceased; also includes the case where the vital status is unknown.",
+    "mode": "NULLABLE",
+    "name": "vital_status",
+    "type": "STRING"
+  },
+  {
+    "description": "Number of days between the date used for index and the date from a person's date of death represented as a calculated number of days.",
+    "mode": "NULLABLE",
+    "name": "days_to_death",
+    "type": "INTEGER"
+  },
+  {
+    "description": "Coded value indicating the circumstance or condition that results in the death of the subject.",
+    "mode": "NULLABLE",
+    "name": "cause_of_death",
+    "type": "STRING"
+  },
+  {
+    "description": "List of ids of File entities associated with the Patient",
+    "mode": "REPEATED",
+    "name": "Files",
+    "type": "STRING"
+  },
+  {
+    "description": "A research subject is the entity of interest in a specific research study or project, typically a human being or an animal, but can also be a device, group of humans or animals, or a tissue sample. Human research subjects are usually not traceable to a particular person to protect the subject\u2019s privacy.  This entity plays the role of the case_id in existing data.",
+    "fields": [
+      {
+        "description": "The 'logical' identifier of the entity in the system of record, e.g. a UUID.  This 'id' is unique within a given system. The identified entity may have a different 'id' in a different system. For CDA, this is case_id.",
+        "mode": "REQUIRED",
+        "name": "id",
+        "type": "STRING"
+      },
+      {
+        "description": "A 'business' identifier for the entity, typically as provided by an external system or authority, that persists across implementing systems  (i.e. a  'logical' identifier). Uses a specialized, complex 'Identifier' data type to capture information about the source of the business identifier - or a URI expressed as a string to an existing entity. ",
+        "fields": [
+          {
+            "description": "The system or namespace that defines the identifier.",
+            "mode": "NULLABLE",
+            "name": "system",
+            "type": "STRING"
+          },
+          {
+            "description": "The value of the identifier, as defined by the system.",
+            "mode": "NULLABLE",
+            "name": "value",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "identifier",
+        "type": "RECORD"
+      },
+      {
+        "description": "A reference to the Study(s) of which this ResearchSubject is a member.",
+        "mode": "NULLABLE",
+        "name": "member_of_research_project",
+        "type": "STRING"
+      },
+      {
+        "description": "The text term used to describe the type of malignant disease, as categorized by the World Health Organization's (WHO) International Classification of Diseases for Oncology (ICD-O).   This attribute represents the disease that qualified the subject for inclusion on the ResearchProject.",
+        "mode": "NULLABLE",
+        "name": "primary_diagnosis_condition",
+        "type": "STRING"
+      },
+      {
+        "description": "The text term used to describe the primary site of disease, as categorized by the World Health Organization's (WHO) International Classification of Diseases for Oncology (ICD-O). This categorization groups cases into general categories.  This attribute represents the primary site of disease that qualified the subject for inclusion on the ResearchProject.",
+        "mode": "NULLABLE",
+        "name": "primary_diagnosis_site",
+        "type": "STRING"
+      },
+      {
+        "description": "List of ids of File entities associated with the ResearchSubject",
+        "mode": "REPEATED",
+        "name": "Files",
+        "type": "STRING"
+      },
+      {
+        "description": "A collection of characteristics that describe an abnormal condition of the body as assessed at a point in time. May be used to capture information about neoplastic and non-neoplastic conditions.",
+        "fields": [
+          {
+            "description": "The 'logical' identifier of the entity in the repository, e.g. a UUID.  This 'id' is unique within a given system. The identified entity may have a different 'id' in a different system.",
+            "mode": "REQUIRED",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "description": "A 'business' identifier  or accession number for the entity, typically as provided by an external system or authority, that persists across implementing systems  (i.e. a  'logical' identifier). ",
+            "fields": [
+              {
+                "description": "The system or namespace that defines the identifier.",
+                "mode": "NULLABLE",
+                "name": "system",
+                "type": "STRING"
+              },
+              {
+                "description": "The value of the identifier, as defined by the system.",
+                "mode": "NULLABLE",
+                "name": "value",
+                "type": "STRING"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "identifier",
+            "type": "RECORD"
+          },
+          {
+            "description": "The diagnosis instance that qualified a subject for inclusion on a ResearchProject",
+            "mode": "NULLABLE",
+            "name": "primary_diagnosis",
+            "type": "STRING"
+          },
+          {
+            "description": "The age in days of the individual at the time of diagnosis",
+            "mode": "NULLABLE",
+            "name": "age_at_diagnosis",
+            "type": "INTEGER"
+          },
+          {
+            "description": "Code that represents the histology of the disease using the third edition of the International Classification of Diseases for Oncology, published in 2000, used principally in tumor and cancer registri",
+            "mode": "NULLABLE",
+            "name": "morphology",
+            "type": "STRING"
+          },
+          {
+            "description": "The extent of a cancer in the body. Staging is usually based on the size of the tumor, whether lymph nodes contain cancer, and whether the cancer has spread from the original site to other parts of the body.",
+            "mode": "NULLABLE",
+            "name": "stage",
+            "type": "STRING"
+          },
+          {
+            "description": "The degree of abnormality of cancer cells, a measure of differentiation, the extent to which cancer cells are similar in appearance and function to healthy cells of the same tissue type. The degree of differentiation often relates to the clinical behavior of the particular tumor. Based on the microscopic findings, tumor grade is commonly described by one of four degrees of severity. Histopathologic grade of a tumor may be used to plan treatment and estimate the future course, outcome, and overall prognosis of disease. Certain types of cancers, such as soft tissue sarcoma, primary brain tumors, lymphomas, and breast have special grading systems.",
+            "mode": "NULLABLE",
+            "name": "grade",
+            "type": "STRING"
+          },
+          {
+            "description": "The method used to confirm the patients malignant diagnosis",
+            "mode": "NULLABLE",
+            "name": "method_of_diagnosis",
+            "type": "STRING"
+          },
+          {
+            "description": "Represent medication administration or other treatment types.",
+            "fields": [
+              {
+                "description": "The 'logical' identifier of the entity in the repository, e.g. a UUID.  This 'id' is unique within a given system. The identified entity may have a different 'id' in a different system.",
+                "mode": "REQUIRED",
+                "name": "id",
+                "type": "STRING"
+              },
+              {
+                "description": "A 'business' identifier  or accession number for the entity, typically as provided by an external system or authority, that persists across implementing systems  (i.e. a  'logical' identifier). ",
+                "fields": [
+                  {
+                    "description": "The system or namespace that defines the identifier.",
+                    "mode": "NULLABLE",
+                    "name": "system",
+                    "type": "STRING"
+                  },
+                  {
+                    "description": "The value of the identifier, as defined by the system.",
+                    "mode": "NULLABLE",
+                    "name": "value",
+                    "type": "STRING"
+                  }
+                ],
+                "mode": "REPEATED",
+                "name": "identifier",
+                "type": "RECORD"
+              },
+              {
+                "description": "The treatment type including medication/therapeutics or other procedures.",
+                "mode": "NULLABLE",
+                "name": "treatment_type",
+                "type": "STRING"
+              },
+              {
+                "description": "The final outcome of the treatment.",
+                "mode": "NULLABLE",
+                "name": "treatment_outcome",
+                "type": "STRING"
+              },
+              {
+                "description": "The timepoint at which the treatment started.",
+                "mode": "NULLABLE",
+                "name": "days_to_treatment_start",
+                "type": "INTEGER"
+              },
+              {
+                "description": " The timepoint at which the treatment ended.",
+                "mode": "NULLABLE",
+                "name": "days_to_treatment_end",
+                "type": "INTEGER"
+              },
+              {
+                "description": "One or more therapeutic agents as part of this treatment.",
+                "mode": "NULLABLE",
+                "name": "therapeutic_agent",
+                "type": "STRING"
+              },
+              {
+                "description": "The anatomical site that the treatment targets.",
+                "mode": "NULLABLE",
+                "name": "treatment_anatomic_site",
+                "type": "STRING"
+              },
+              {
+                "description": "The effect of a treatment on the diagnosis or tumor.",
+                "mode": "NULLABLE",
+                "name": "treatment_effect",
+                "type": "STRING"
+              },
+              {
+                "description": "The reason the treatment ended.",
+                "mode": "NULLABLE",
+                "name": "treatment_end_reason",
+                "type": "STRING"
+              },
+              {
+                "description": "The number of treatment cycles the subject received.",
+                "mode": "NULLABLE",
+                "name": "number_of_cycles",
+                "type": "INTEGER"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "Treatment",
+            "type": "RECORD"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "Diagnosis",
+        "type": "RECORD"
+      },
+      {
+        "description": "Any material taken as a sample from a biological entity (living or dead), or from a physical object or the environment. Specimens are usually collected as an example of their kind, often for use in some investigation.",
+        "fields": [
+          {
+            "description": "The 'logical' identifier of the entity in the system of record, e.g. a UUID.  This 'id' is unique within a given system. The identified entity may have a different 'id' in a different system.",
+            "mode": "REQUIRED",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "description": "A 'business' identifier  or accession number for the entity, typically as provided by an external system or authority, that persists across implementing systems  (i.e. a  'logical' identifier). ",
+            "fields": [
+              {
+                "description": "The system or namespace that defines the identifier.",
+                "mode": "NULLABLE",
+                "name": "system",
+                "type": "STRING"
+              },
+              {
+                "description": "The value of the identifier, as defined by the system.",
+                "mode": "NULLABLE",
+                "name": "value",
+                "type": "STRING"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "identifier",
+            "type": "RECORD"
+          },
+          {
+            "description": "The Project associated with the specimen.",
+            "mode": "NULLABLE",
+            "name": "associated_project",
+            "type": "STRING"
+          },
+          {
+            "description": "The number of days from the index date to either the date a sample was collected for a specific study or project, or the date a patient underwent a procedure (e.g. surgical resection) yielding a sample that was eventually used for research.",
+            "mode": "NULLABLE",
+            "name": "days_to_collection",
+            "type": "INTEGER"
+          },
+          {
+            "description": "The text term used to describe the type of malignant disease, as categorized by the World Health Organization's (WHO) International Classification of Diseases for Oncology (ICD-O).   This attribute represents the disease that qualified the subject for inclusion on the ResearchProject.",
+            "mode": "NULLABLE",
+            "name": "primary_disease_type",
+            "type": "STRING"
+          },
+          {
+            "description": "Per GDC Dictionary, the text term that represents the name of the primary disease site of the submitted tumor sample; recommend dropping tumor; biospecimen_anatomic_site.",
+            "mode": "NULLABLE",
+            "name": "anatomical_site",
+            "type": "STRING"
+          },
+          {
+            "description": "The general kind of material from which the specimen was derived, indicating the physical nature of the source material. ",
+            "mode": "NULLABLE",
+            "name": "source_material_type",
+            "type": "STRING"
+          },
+          {
+            "description": "The high-level type of the specimen, based on its how it has been derived from the original extracted sample. \n",
+            "mode": "NULLABLE",
+            "name": "specimen_type",
+            "type": "STRING"
+          },
+          {
+            "description": "A source/parent specimen from which this one was directly derived.",
+            "mode": "NULLABLE",
+            "name": "derived_from_specimen",
+            "type": "STRING"
+          },
+          {
+            "description": "The Patient/ResearchSubject, or Biologically Derived Materal (e.g. a cell line, tissue culture, organoid) from which the specimen was directly or indirectly derived.",
+            "mode": "NULLABLE",
+            "name": "derived_from_subject",
+            "type": "STRING"
+          },
+          {
+            "description": "List of ids of File entities associated with the Specimen",
+            "mode": "REPEATED",
+            "name": "Files",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "Specimen",
+        "type": "RECORD"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "ResearchSubject",
+    "type": "RECORD"
+  }
+]


### PR DESCRIPTION
Currently, the API correctly validates that a column exists in the schema when passed a Column object as part of the larger `=`, `IN`, `!=`, ,etc. operators. It does this by throwing an IllegalArgumentException which results in a 400 error to the user. However, SelectValues was not behaving this way and would give a 500 if the user passed a value that does not exist in the schema.

To resolve this, the validation is being moved to the QueryFieldBuilder method that is shared among all of the operators that need to parse path strings.