### PR TITLE
update to correct table name

### DIFF
--- a/src/main/resources/schema/somatic_mutation_hg38_gdc_v3_1_final.json
+++ b/src/main/resources/schema/somatic_mutation_hg38_gdc_v3_1_final.json
@@ -681,7 +681,7 @@
             "researchsubject_id"
           ],
           "type": "SINGLE",
-          "tableName": "all_Subjects_v3_1_test1",
+          "tableName": "all_Subjects_v3_1_final",
           "tableAlias": "researchsubjects",
           "location": "ResearchSubject"
         }


### PR DESCRIPTION
One of the schemas was pointing to the wrong table causing a 500 error.