### PR TITLE
Fix for swagger UI not appearing

### DIFF
--- a/src/main/java/bio/terra/cda/app/configuration/ApiResourceConfig.java
+++ b/src/main/java/bio/terra/cda/app/configuration/ApiResourceConfig.java
@@ -10,7 +10,7 @@ public class ApiResourceConfig implements WebMvcConfigurer {
   public void addResourceHandlers(ResourceHandlerRegistry registry) {
     registry
         .addResourceHandler("/api/swagger-webjar/**")
-        .addResourceLocations("classpath:/META-INF/resources/webjars/swagger-ui/3.24.0/");
+        .addResourceLocations("classpath:/META-INF/resources/webjars/swagger-ui/4.14.0/");
     registry.addResourceHandler("/api/**").addResourceLocations("classpath:/api/");
   }
 }


### PR DESCRIPTION
The version of swagger was recently updated, but the Resource Config that builds a handler for the UI portion of swagger was referencing the old version of swagger causing the page to not load properly.