### PR TITLE
Remove caching from response header

### DIFF
--- a/src/main/java/bio/terra/cda/app/controller/GlobalExceptionHandler.java
+++ b/src/main/java/bio/terra/cda/app/controller/GlobalExceptionHandler.java
@@ -67,6 +67,6 @@ public class GlobalExceptionHandler {
       errorReport =
           new ErrorReport().message(ex.getMessage()).statusCode(statusCode.value()).causes(causes);
     }
-    return new ResponseEntity<>(errorReport, statusCode);
+    return new ResponseEntity<>(errorReport, HeaderUtils.getNoCacheResponseHeader(), statusCode);
   }
 }

--- a/src/main/java/bio/terra/cda/app/controller/HeaderUtils.java
+++ b/src/main/java/bio/terra/cda/app/controller/HeaderUtils.java
@@ -1,0 +1,15 @@
+package bio.terra.cda.app.controller;
+
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
+
+public class HeaderUtils {
+
+    public static HttpHeaders getNoCacheResponseHeader(){
+        HttpHeaders responseHeaders = new HttpHeaders();
+        responseHeaders.setCacheControl(CacheControl.noStore());
+        responseHeaders.setPragma("no-cache");
+        return responseHeaders;
+    }
+
+}

--- a/src/main/java/bio/terra/cda/app/controller/MetaApiController.java
+++ b/src/main/java/bio/terra/cda/app/controller/MetaApiController.java
@@ -44,7 +44,7 @@ public class MetaApiController implements MetaApi {
   @TrackExecutionTime
   @Override
   public ResponseEntity<SystemStatus> serviceStatus() {
-    return ResponseEntity.ok(queryService.postgresCheck());
+    return ResponseEntity.ok().headers(HeaderUtils.getNoCacheResponseHeader()).body(queryService.postgresCheck());
   }
 
   // For now, the dataset description is hardcoded. In the future, it will probably be read from a

--- a/src/main/java/bio/terra/cda/app/controller/MetaApiController.java
+++ b/src/main/java/bio/terra/cda/app/controller/MetaApiController.java
@@ -22,7 +22,10 @@ import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import org.apache.http.Header;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -63,12 +66,12 @@ public class MetaApiController implements MetaApi {
 
   @Override
   public ResponseEntity<List<DatasetDescription>> allReleaseNotes() {
-    return ResponseEntity.ok(Collections.singletonList(createDescription()));
+    return ResponseEntity.ok().headers(HeaderUtils.getNoCacheResponseHeader()).body(Collections.singletonList(createDescription()));
   }
 
   @Override
   public ResponseEntity<DatasetDescription> latestReleaseNotes() {
-    return ResponseEntity.ok(createDescription());
+    return ResponseEntity.ok().headers(HeaderUtils.getNoCacheResponseHeader()).body(createDescription());
   }
 
 }

--- a/src/main/java/bio/terra/cda/app/controller/QueryApiController.java
+++ b/src/main/java/bio/terra/cda/app/controller/QueryApiController.java
@@ -134,22 +134,6 @@ public class QueryApiController implements QueryApi {
 
   }
 
-  // region Global Queries
-  @TrackExecutionTime
-  @Override
-  public ResponseEntity<PagedResponseData> bulkData(
-      @Valid String table, @Valid Boolean includeCount, @Valid Integer offset, @Valid Integer limit) {
-    logger.info("executing bulkData query");
-    assert(RdbmsSchema.getDataSetInfo().getTableInfo(table) != null);
-    String querySql = "SELECT * FROM " + table;
-    List<JsonNode> result = queryService.runPagedQuery(querySql, offset, limit);
-    return new ResponseEntity<>(
-        new PagedResponseData()
-            .querySql(querySql)
-            .result(Collections.unmodifiableList(result)),
-        HttpStatus.OK);
-  }
-
   @TrackExecutionTime
   @Override
   public ResponseEntity<PagedResponseData> booleanQuery(

--- a/src/main/java/bio/terra/cda/app/controller/QueryApiController.java
+++ b/src/main/java/bio/terra/cda/app/controller/QueryApiController.java
@@ -136,15 +136,6 @@ public class QueryApiController implements QueryApi {
 
   @TrackExecutionTime
   @Override
-  public ResponseEntity<PagedResponseData> booleanQuery(
-      @Valid Query body, @Valid Boolean dryRun, @Valid Boolean includeCount, @Valid Integer offset, @Valid Integer limit) {
-    PagedResponseData response = handleRequest(dryRun, new SubjectSqlGenerator(body, false), includeCount, offset, limit);
-    checkAndSetNextUrl(response, "boolean-query", offset, limit);
-    return new ResponseEntity<>(response, HttpStatus.OK);
-  }
-
-  @TrackExecutionTime
-  @Override
   public ResponseEntity<PagedResponseData> uniqueValues(
       @Valid String body,  @Valid String system,  @Valid Boolean count, @Valid Boolean includeCount, @Valid Integer offset, @Valid Integer limit) {
     if (count == null) {

--- a/src/main/java/bio/terra/cda/app/controller/QueryApiController.java
+++ b/src/main/java/bio/terra/cda/app/controller/QueryApiController.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
+import org.apache.http.Header;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -143,7 +144,7 @@ public class QueryApiController implements QueryApi {
     }
     PagedResponseData response = handleRequest(false, new QuerySqlGenerator(body, system, count), includeCount, offset, limit);
     checkAndSetNextUrl(response,"unique-values", offset, limit);
-    return new ResponseEntity<>(response, HttpStatus.OK);
+    return new ResponseEntity<>(response, HeaderUtils.getNoCacheResponseHeader(), HttpStatus.OK);
   }
 
   @TrackExecutionTime
@@ -171,7 +172,7 @@ public class QueryApiController implements QueryApi {
     ColumnsResponseData queryResponseData = new ColumnsResponseData();
     queryResponseData.result(Collections.unmodifiableList(results));
 
-    return new ResponseEntity<>(queryResponseData, HttpStatus.OK);
+    return new ResponseEntity<>(queryResponseData, HeaderUtils.getNoCacheResponseHeader(), HttpStatus.OK);
   }
 
   @TrackExecutionTime
@@ -180,6 +181,7 @@ public class QueryApiController implements QueryApi {
       @Valid Query body, @Valid Boolean dryRun) {
     return new ResponseEntity<>(
         handleRequest(dryRun, new CountsSqlGenerator(body)),
+        HeaderUtils.getNoCacheResponseHeader(),
         HttpStatus.OK);
   }
 
@@ -190,7 +192,7 @@ public class QueryApiController implements QueryApi {
         @Valid Query body, @Valid Boolean dryRun, @Valid Boolean includeCount, @Valid Integer offset, @Valid Integer limit) {
     PagedResponseData response = handleRequest(dryRun, new FileSqlGenerator(body), includeCount, offset, limit);
     checkAndSetNextUrl(response,"files", offset, limit);
-    return new ResponseEntity<>(response, HttpStatus.OK);
+    return new ResponseEntity<>(response, HeaderUtils.getNoCacheResponseHeader(), HttpStatus.OK);
     }
 
     @TrackExecutionTime
@@ -199,6 +201,7 @@ public class QueryApiController implements QueryApi {
         @Valid Query body, @Valid Boolean dryRun) {
       return new ResponseEntity<>(
           handleRequest(dryRun, new SubjectCountSqlGenerator(body, true)),
+          HeaderUtils.getNoCacheResponseHeader(),
           HttpStatus.OK);
     }
     // endregion
@@ -210,7 +213,7 @@ public class QueryApiController implements QueryApi {
         @Valid Query body, @Valid Boolean dryRun, @Valid Boolean includeCount, @Valid Integer offset, @Valid Integer limit) {
       PagedResponseData response = handleRequest(dryRun, new SubjectSqlGenerator(body, false), includeCount, offset, limit);
       checkAndSetNextUrl(response,"subjects", offset, limit);
-      return new ResponseEntity<>(response, HttpStatus.OK);
+      return new ResponseEntity<>(response, HeaderUtils.getNoCacheResponseHeader(), HttpStatus.OK);
     }
 
     @TrackExecutionTime
@@ -220,7 +223,7 @@ public class QueryApiController implements QueryApi {
     PagedResponseData response =
         handleRequest(dryRun, new SubjectSqlGenerator(body, true), includeCount, offset, limit);
         checkAndSetNextUrl(response,"subjects/files", offset, limit);
-      return new ResponseEntity<>(response, HttpStatus.OK);
+      return new ResponseEntity<>(response, HeaderUtils.getNoCacheResponseHeader(), HttpStatus.OK);
     }
 
   @TrackExecutionTime
@@ -229,6 +232,7 @@ public class QueryApiController implements QueryApi {
       @Valid Query body, @Valid Boolean dryRun) {
     return new ResponseEntity<>(
         handleRequest(dryRun, new SubjectCountSqlGenerator(body, false)),
+        HeaderUtils.getNoCacheResponseHeader(),
         HttpStatus.OK);
   }
 
@@ -237,7 +241,8 @@ public class QueryApiController implements QueryApi {
   public ResponseEntity<QueryResponseData> subjectFileCountsQuery(
       @Valid Query body, @Valid Boolean dryRun) {
     return new ResponseEntity<>(
-        handleRequest(dryRun, new SubjectCountSqlGenerator(body, true)), HttpStatus.OK);
+        handleRequest(dryRun, new SubjectCountSqlGenerator(body, true)),
+        HeaderUtils.getNoCacheResponseHeader(), HttpStatus.OK);
   }
   // endregion
 
@@ -250,7 +255,7 @@ public class QueryApiController implements QueryApi {
       @Valid Query body, @Valid Boolean dryRun, @Valid Boolean includeCount, @Valid Integer offset, @Valid Integer limit) {
     PagedResponseData response = handleRequest(dryRun, new ResearchSubjectSqlGenerator(body, false), includeCount, offset, limit);
     checkAndSetNextUrl(response,"researchsubjects", offset, limit);
-    return new ResponseEntity<>(response, HttpStatus.OK);
+    return new ResponseEntity<>(response, HeaderUtils.getNoCacheResponseHeader(), HttpStatus.OK);
   }
 
   @TrackExecutionTime
@@ -259,7 +264,7 @@ public class QueryApiController implements QueryApi {
       @Valid Query body, @Valid Boolean dryRun, @Valid Boolean includeCount, @Valid Integer offset, @Valid Integer limit) {
     PagedResponseData response = handleRequest(dryRun, new ResearchSubjectSqlGenerator(body, true), includeCount, offset, limit);
     checkAndSetNextUrl(response,"researchsubjects/files", offset, limit);
-    return new ResponseEntity<>(response, HttpStatus.OK);
+    return new ResponseEntity<>(response, HeaderUtils.getNoCacheResponseHeader(), HttpStatus.OK);
   }
 
   @TrackExecutionTime
@@ -267,7 +272,7 @@ public class QueryApiController implements QueryApi {
   public ResponseEntity<QueryResponseData> researchSubjectCountsQuery(
       @Valid Query body, @Valid Boolean dryRun) {
     return new ResponseEntity<>(
-        handleRequest(dryRun, new ResearchSubjectCountSqlGenerator(body)),
+        handleRequest(dryRun, new ResearchSubjectCountSqlGenerator(body)), HeaderUtils.getNoCacheResponseHeader(),
         HttpStatus.OK);
   }
 
@@ -276,7 +281,8 @@ public class QueryApiController implements QueryApi {
   public ResponseEntity<QueryResponseData> researchSubjectFileCountsQuery(
       @Valid Query body, @Valid Boolean dryRun) {
     return new ResponseEntity<>(
-        handleRequest(dryRun, new ResearchSubjectCountSqlGenerator(body, true)), HttpStatus.OK);
+        handleRequest(dryRun, new ResearchSubjectCountSqlGenerator(body, true)),
+        HeaderUtils.getNoCacheResponseHeader(), HttpStatus.OK);
   }
   // endregion
 
@@ -287,7 +293,7 @@ public class QueryApiController implements QueryApi {
       @Valid Query body, @Valid Boolean dryRun, @Valid Boolean includeCount, @Valid Integer offset, @Valid Integer limit) {
     PagedResponseData response = handleRequest(dryRun, new SpecimenSqlGenerator(body, false), includeCount, offset, limit);
     checkAndSetNextUrl(response,"specimen", offset, limit);
-    return new ResponseEntity<>(response, HttpStatus.OK);
+    return new ResponseEntity<>(response, HeaderUtils.getNoCacheResponseHeader(), HttpStatus.OK);
   }
 
   @TrackExecutionTime
@@ -296,7 +302,7 @@ public class QueryApiController implements QueryApi {
       @Valid Query body, @Valid Boolean dryRun, @Valid Boolean includeCount, @Valid Integer offset, @Valid Integer limit) {
     PagedResponseData response = handleRequest(dryRun, new SpecimenSqlGenerator(body, true), includeCount, offset, limit);
     checkAndSetNextUrl(response,"specimen/files", offset, limit);
-    return new ResponseEntity<>(response, HttpStatus.OK);
+    return new ResponseEntity<>(response, HeaderUtils.getNoCacheResponseHeader(), HttpStatus.OK);
   }
 
   @TrackExecutionTime
@@ -304,7 +310,7 @@ public class QueryApiController implements QueryApi {
   public ResponseEntity<QueryResponseData> specimenCountsQuery(
       @Valid Query body, @Valid Boolean dryRun) {
     return new ResponseEntity<>(
-        handleRequest(dryRun, new SpecimenCountSqlGenerator(body)),
+        handleRequest(dryRun, new SpecimenCountSqlGenerator(body)), HeaderUtils.getNoCacheResponseHeader(),
         HttpStatus.OK);
   }
 
@@ -314,6 +320,7 @@ public class QueryApiController implements QueryApi {
       @Valid Query body, @Valid Boolean dryRun) {
     return new ResponseEntity<>(
         handleRequest(dryRun, new SpecimenCountSqlGenerator(body, true)),
+        HeaderUtils.getNoCacheResponseHeader(),
         HttpStatus.OK);
   }
   // endregion
@@ -325,7 +332,7 @@ public class QueryApiController implements QueryApi {
       @Valid Query body, @Valid Boolean dryRun, @Valid Boolean includeCount, @Valid Integer offset, @Valid Integer limit) {
     PagedResponseData response = handleRequest(dryRun, new DiagnosisSqlGenerator(body), includeCount, offset, limit);
     checkAndSetNextUrl(response,"diagnosis", offset, limit);
-    return new ResponseEntity<>(response, HttpStatus.OK);
+    return new ResponseEntity<>(response, HeaderUtils.getNoCacheResponseHeader(), HttpStatus.OK);
   }
 
   @TrackExecutionTime
@@ -333,7 +340,7 @@ public class QueryApiController implements QueryApi {
   public ResponseEntity<QueryResponseData> diagnosisCountsQuery(
       @Valid Query body, @Valid Boolean dryRun) {
     return  new ResponseEntity<>(
-        handleRequest(dryRun, new DiagnosisCountSqlGenerator(body)),
+        handleRequest(dryRun, new DiagnosisCountSqlGenerator(body)), HeaderUtils.getNoCacheResponseHeader(),
         HttpStatus.OK);
   }
   // endregion
@@ -345,7 +352,7 @@ public class QueryApiController implements QueryApi {
       @Valid Query body, @Valid Boolean dryRun, @Valid Boolean includeCount, @Valid Integer offset, @Valid Integer limit) {
     PagedResponseData response = handleRequest(dryRun, new TreatmentSqlGenerator(body), includeCount, offset, limit);
     checkAndSetNextUrl(response,"treatments", offset, limit);
-    return new ResponseEntity<>(response, HttpStatus.OK);
+    return new ResponseEntity<>(response, HeaderUtils.getNoCacheResponseHeader(), HttpStatus.OK);
   }
 
   @TrackExecutionTime
@@ -353,7 +360,7 @@ public class QueryApiController implements QueryApi {
   public ResponseEntity<QueryResponseData> treatmentCountsQuery(
       @Valid Query body, @Valid Boolean dryRun) {
     return new ResponseEntity<>(
-        handleRequest(dryRun, new TreatmentCountSqlGenerator(body)),
+        handleRequest(dryRun, new TreatmentCountSqlGenerator(body)), HeaderUtils.getNoCacheResponseHeader(),
         HttpStatus.OK);
   }
   // endregion
@@ -365,7 +372,7 @@ public class QueryApiController implements QueryApi {
       @Valid Query body, @Valid Boolean dryRun, @Valid Boolean includeCount, @Valid Integer offset, @Valid Integer limit) {
     PagedResponseData response = handleRequest(dryRun, new MutationSqlGenerator(body), includeCount, offset, limit);
     checkAndSetNextUrl(response,"treatments", offset, limit);
-    return new ResponseEntity<>(response, HttpStatus.OK);
+    return new ResponseEntity<>(response, HeaderUtils.getNoCacheResponseHeader(), HttpStatus.OK);
   }
 
   @TrackExecutionTime
@@ -373,7 +380,7 @@ public class QueryApiController implements QueryApi {
   public ResponseEntity<QueryResponseData> mutationCountsQuery(
       @Valid Query body, @Valid Boolean dryRun) {
     return new ResponseEntity<>(
-        handleRequest(dryRun, new MutationCountSqlGenerator(body)),
+        handleRequest(dryRun, new MutationCountSqlGenerator(body)), HeaderUtils.getNoCacheResponseHeader(),
         HttpStatus.OK);
   }
   // endregion

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -78,35 +78,6 @@ paths:
                 items:
                   $ref: "#/components/schemas/DatasetDescription"
 
-  /api/v1/boolean-query:
-    post:
-      summary: Execute boolean query
-      description: |
-        Execute a query composed of conditions on columns combined with boolean operators. The
-        generated SQL query is returned in the response.
-      operationId: booleanQuery
-      tags:
-        - query
-
-      parameters:
-        - $ref: "#/components/parameters/DryRun"
-        - $ref: "#/components/parameters/IncludeResultsCount"
-        - $ref: "#/components/parameters/ResultOffset"
-        - $ref: "#/components/parameters/ResultLimit"
-
-
-      requestBody:
-        description: The boolean query
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Query"
-
-      responses:
-        200:
-          $ref: "#/components/responses/PagedResponse"
-
   /api/v1/subjects:
     post:
       summary: Execute Subject query

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -78,23 +78,6 @@ paths:
                 items:
                   $ref: "#/components/schemas/DatasetDescription"
 
-  /api/v1/bulk-data:
-    get:
-      summary: Return all data in CDA
-      description: Return all data in CDA
-      operationId: bulkData
-      tags:
-        - query
-      parameters:
-        - $ref: "#/components/parameters/Table"
-        - $ref: "#/components/parameters/IncludeResultsCount"
-        - $ref: "#/components/parameters/ResultOffset"
-        - $ref: "#/components/parameters/ResultLimit"
-      responses:
-        200:
-          $ref: "#/components/responses/PagedResponse"
-
-
   /api/v1/boolean-query:
     post:
       summary: Execute boolean query


### PR DESCRIPTION
Added code to affect caching controls in all of our response headers, to include: 
Cache-control: no-store
Pragma: no-cache       

NOTE: there is probably a better way to do this by using spring security controls at the application level. It may also be possible to do this via the openapi spec. It was my opinion that just changing the individual endpoints was easier and a smaller change now - but we can revisit this implementation in the future. 