### PR TITLE
Fixed Join Keep in Paged Query

### DIFF
--- a/src/main/java/bio/terra/cda/app/service/FilterUtils.java
+++ b/src/main/java/bio/terra/cda/app/service/FilterUtils.java
@@ -2,6 +2,10 @@ package bio.terra.cda.app.service;
 
 import java.text.CharacterIterator;
 import java.text.StringCharacterIterator;
+import java.util.HashMap;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class FilterUtils{
     public static String trimExtraneousParentheses(String query) {
@@ -46,4 +50,12 @@ public class FilterUtils{
         }
         return startingString.substring(0, indexCursor+1);
     }
+    public static void addUniqueMatchesToSet(String stringToSearch, String regex, Set<String> set){
+        Pattern pattern = Pattern.compile(regex);
+        Matcher m = pattern.matcher(stringToSearch);
+        while (m.find()) {
+            set.add(m.group(1));
+        }
+    }
+
 }


### PR DESCRIPTION
Rebuilt logic for dropping unnecessary joins. I now build a join path to get all required tables to join on any tables found in the select clause. Then I only remove any join statements that don't include any of these tables.